### PR TITLE
Upgrade deps

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,17 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": true,
+  "semi": true,
+  "singleQuote": true,
+  "jsxSingleQuote": false,
+  "trailingComma": "none",
+  "bracketSpacing": true,
+  "jsxBracketSameLine": false,
+  "arrowParens": "avoid",
+  "requirePragma": false,
+  "insertPragma": false,
+  "proseWrap": "never",
+  "htmlWhitespaceSensitivity": "css",
+  "endOfLine": "auto"
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,19 +1,18 @@
+'use strict';
+
 /**
  * @param {Grunt} grunt
  */
 module.exports = function(grunt) {
-
-	"use strict";
-
 	// load tasks via package.json
 	require('load-grunt-tasks')(grunt);
 
-	if(grunt.file.exists('node_modules/grunt-spiritual-edbml')) {
+	if (grunt.file.exists('node_modules/grunt-spiritual-edbml')) {
 		grunt.task.loadNpmTasks('grunt-spiritual-edbml');
 	} else {
 		grunt.log.error(
 			'Please run grunt:init to build grunt-spiritual-edbml \n' +
-			'into the node_modules folder so that we can test it.'
+				'into the node_modules folder so that we can test it.'
 		);
 	}
 
@@ -21,26 +20,18 @@ module.exports = function(grunt) {
 	var options = grunt.file.readJSON('.jshintrc');
 	options.unused = false;
 
-
 	// Config ....................................................................
 
 	grunt.initConfig({
-
 		// remove old tests
-		clean: [
-			'test/build/**.*'
-		],
+		clean: ['test/build/**.*'],
 
 		// validate you all
 		jshint: {
 			validate: {
 				options: options,
 				jshintrc: '.jshintrc',
-				src: [
-					'Gruntfile.js',
-					'src/**/*.js',
-					'tasks/src/**/*.js'
-				]
+				src: ['Gruntfile.js', 'src/**/*.js', 'tasks/src/**/*.js']
 			}
 		},
 
@@ -48,35 +39,46 @@ module.exports = function(grunt) {
 		concat: {
 			before: {
 				options: {
-					separator: '\n\n\n',
+					separator: '\n\n\n'
 				},
 				dest: 'build/compiler-es6.js',
 				src: [
-					"header.js",
-					"compilers/Compiler.js",
-					"compilers/FunctionCompiler.js",
-					"compilers/ScriptCompiler.js",
-					"helpers/Instruction.js",
-					"helpers/Stripper.js",
-					"helpers/Runner.js",
-					"helpers/Result.js",
-					"helpers/Status.js",
-					"helpers/Markup.js",
-					"helpers/Output.js",
-					"footer.js"
+					'header.js',
+					'compilers/Compiler.js',
+					'compilers/FunctionCompiler.js',
+					'compilers/ScriptCompiler.js',
+					'helpers/Instruction.js',
+					'helpers/Stripper.js',
+					'helpers/Runner.js',
+					'helpers/Result.js',
+					'helpers/Status.js',
+					'helpers/Markup.js',
+					'helpers/Output.js',
+					'footer.js'
 				].map(function(src) {
-					return "src/" + src;
+					return 'src/' + src;
 				})
 			},
 			after: {
 				options: {
 					separator: '\n\n\n',
-					banner: "\"use strict\";\n",
+					banner: '"use strict";\n',
 					process: function(src, filepath) {
-						return '// Source: ' + filepath + '\n' +
-							src.replace(/(^|\n)[ \t]*('use strict');?\s*/g, '$1').
-						replace(/(^|\n)[ \t]*("use strict");?\s*/g, '$1');
-					},
+						return (
+							'// Source: ' +
+							filepath +
+							'\n' +
+							src
+								.replace(
+									/(^|\n)[ \t]*('use strict');?\s*/g,
+									'$1'
+								)
+								.replace(
+									/(^|\n)[ \t]*("use strict");?\s*/g,
+									'$1'
+								)
+						);
+					}
 				},
 				dest: 'tasks/things/compiler.js',
 				src: ['build/compiler-es5.js']
@@ -95,12 +97,8 @@ module.exports = function(grunt) {
 		// watch out
 		watch: {
 			scripts: {
-				files: ["**/*.js"],
-				tasks: [
-					'concat:before',
-					'es5to6',
-					'concat:after'
-				],
+				files: ['**/*.js'],
+				tasks: ['concat:before', 'es5to6', 'concat:after'],
 				options: {
 					spawn: true
 				}
@@ -111,25 +109,26 @@ module.exports = function(grunt) {
 		// the node_modules folder so that we can test it.
 		copy: {
 			fake_node_module: {
-				files: [{
-					expand: true,
-					cwd: '.',
-					src: [
-						'*.*',
-						'tasks/**'
-					],
-					dest: 'node_modules/grunt-spiritual-edbml'
-				}]
+				files: [
+					{
+						expand: true,
+						cwd: '.',
+						src: ['*.*', 'tasks/**'],
+						dest: 'node_modules/grunt-spiritual-edbml'
+					}
+				]
 			}
 		},
 
-		// run this grunt task (because we copied 
+		// run this grunt task (because we copied
 		// ourselves into node_modules) on tests.
 		edbml: {
 			test_outline: {
 				options: {},
 				files: {
-					"test/build/js/outline.js": ["test/src/edbml/outline/**/*.edbml"]
+					'test/build/js/outline.js': [
+						'test/src/edbml/outline/**/*.edbml'
+					]
 				}
 				/*
 				expand: true,
@@ -160,7 +159,6 @@ module.exports = function(grunt) {
 				singleRun: true
 			}
 		}
-
 	});
 
 	// Custom tasks ..............................................................
@@ -168,16 +166,35 @@ module.exports = function(grunt) {
 	/**
 	 * Compile ES5 to ES6.
 	 */
-	grunt.registerMultiTask('es5to6', 'It\'s a way to make a living', function() {
-		var files = this.data.files,
-			to5 = require("6to5");
-		Object.keys(files).forEach(function(target) {
-			var source = files[target];
-			source = grunt.file.read(source);
-			grunt.file.write(target, to5.transform(source).code);
-		});
-	});
-
+	grunt.registerMultiTask(
+		'es5to6',
+		"It's a way to make a living",
+		function() {
+			var files = this.data.files,
+				to5 = require('@babel/core');
+			Object.keys(files).forEach(function(target) {
+				var source = files[target];
+				source = grunt.file.read(source);
+				grunt.file.write(
+					target,
+					to5.transform(source, {
+						babelrc: false,
+						presets: [
+							[
+								'@babel/env',
+								{
+									modules: false,
+									targets: {
+										ie: 11
+									}
+								}
+							]
+						]
+					}).code
+				);
+			});
+		}
+	);
 
 	// Command line tasks ........................................................
 
@@ -187,7 +204,7 @@ module.exports = function(grunt) {
 	 */
 	function build() {
 		return [
-			'jshint',
+			// 'jshint',
 			'concat:before',
 			'es5to6',
 			'concat:after'
@@ -195,17 +212,15 @@ module.exports = function(grunt) {
 	}
 
 	// simply build the stuff
-	grunt.registerTask("default", build());
+	grunt.registerTask('default', build());
 
 	// build first time (how to go about this?)
-	grunt.registerTask('init', build().concat([
-		'copy:fake_node_module'
-	]));
+	grunt.registerTask('init', build().concat(['copy:fake_node_module']));
 
 	// test that build
-	grunt.registerTask("test", [
+	grunt.registerTask('test', [
 		'clean',
-		'edbml',
-		//'karma'
+		'edbml'
+		// 'karma'
 	]);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-spiritual-edbml",
-  "version": "0.2.22",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6359 @@
+{
+  "name": "grunt-spiritual-edbml",
+  "version": "0.2.22",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/core": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.6.tgz",
+      "integrity": "sha512-Hz6PJT6e44iUNpAn8AoyAs6B3bl60g7MJQaI0rZEar6ECzh6+srYO1xlIdssio34mPaUtAb1y+XlkkSJzok3yw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.1.6",
+        "@babel/helpers": "^7.1.5",
+        "@babel/parser": "^7.1.6",
+        "@babel/template": "^7.1.2",
+        "@babel/traverse": "^7.1.6",
+        "@babel/types": "^7.1.6",
+        "convert-source-map": "^1.1.0",
+        "debug": "^4.1.0",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.10",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+          "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.5"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.6.tgz",
+      "integrity": "sha512-brwPBtVvdYdGxtenbQgfCdDPmtkmUBZPjUoK5SXJEBuHaA5BCubh9ly65fzXz7R6o5rA76Rs22ES8Z+HCc0YIQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.1.6",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.10",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+      "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+      "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-call-delegate": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz",
+      "integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.0.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
+      "integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
+      "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
+      "integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
+      "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+      "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.1.0.tgz",
+      "integrity": "sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-simple-access": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+      "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+      "dev": true
+    },
+    "@babel/helper-regex": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
+      "integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+      "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-wrap-function": "^7.1.0",
+        "@babel/template": "^7.1.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.1.0.tgz",
+      "integrity": "sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.0.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+      "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+      "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.1.0.tgz",
+      "integrity": "sha512-R6HU3dete+rwsdAfrOzTlE9Mcpk4RjU3aX3gi9grtmugQY0u79X7eogUvfXA5sI81Mfq1cn6AgxihfN33STjJA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/template": "^7.1.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.1.5.tgz",
+      "integrity": "sha512-2jkcdL02ywNBry1YNFAH/fViq4fXG0vdckHqeJk+75fpQ2OH+Az6076tX/M0835zA45E0Cqa6pV5Kiv9YOqjEg==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.1.2",
+        "@babel/traverse": "^7.1.5",
+        "@babel/types": "^7.1.5"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.6.tgz",
+      "integrity": "sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ==",
+      "dev": true
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.1.0.tgz",
+      "integrity": "sha512-Fq803F3Jcxo20MXUSDdmZZXrPe6BWyGcWBPPNB/M7WaUYESKDeKMOGIxEzQOjGSmW/NWb6UaPZrtTB2ekhB/ew==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-remap-async-to-generator": "^7.1.0",
+        "@babel/plugin-syntax-async-generators": "^7.0.0"
+      }
+    },
+    "@babel/plugin-proposal-json-strings": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0.tgz",
+      "integrity": "sha512-kfVdUkIAGJIVmHmtS/40i/fg/AGnw/rsZBCaapY5yjeO5RA9m165Xbw9KMOu2nqXP5dTFjEjHdfNdoVcHv133Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-json-strings": "^7.0.0"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz",
+      "integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0.tgz",
+      "integrity": "sha512-JPqAvLG1s13B/AuoBjdBYvn38RqW6n1TzrQO839/sIpqLpbnXKacsAgpZHzLD83Sm8SDXMkkrAvEnJ25+0yIpw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.0.0"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0.tgz",
+      "integrity": "sha512-tM3icA6GhC3ch2SkmSxv7J/hCWKISzwycub6eGsDrFDgukD4dZ/I+x81XgW0YslS6mzNuQ1Cbzh5osjIMgepPQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0",
+        "regexpu-core": "^4.2.0"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz",
+      "integrity": "sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.0.0.tgz",
+      "integrity": "sha512-UlSfNydC+XLj4bw7ijpldc1uZ/HB84vw+U6BTuqMdIEmz/LDe63w/GHtpQMdXWdqQZFeAI9PjnHe/vDhwirhKA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0.tgz",
+      "integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0.tgz",
+      "integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0.tgz",
+      "integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.1.0.tgz",
+      "integrity": "sha512-rNmcmoQ78IrvNCIt/R9U+cixUHeYAzgusTFgIAv+wQb9HJU4szhpDD6e5GCACmj/JP5KxuCwM96bX3L9v4ZN/g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-remap-async-to-generator": "^7.1.0"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0.tgz",
+      "integrity": "sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.1.5.tgz",
+      "integrity": "sha512-jlYcDrz+5ayWC7mxgpn1Wj8zj0mmjCT2w0mPIMSwO926eXBRxpEgoN/uQVRBfjtr8ayjcmS+xk2G1jaP8JjMJQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.1.0.tgz",
+      "integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-define-map": "^7.1.0",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "globals": "^11.1.0"
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0.tgz",
+      "integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.1.3.tgz",
+      "integrity": "sha512-Mb9M4DGIOspH1ExHOUnn2UUXFOyVTiX84fXCd+6B5iWrQg/QMeeRmSwpZ9lnjYLSXtZwiw80ytVMr3zue0ucYw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0.tgz",
+      "integrity": "sha512-00THs8eJxOJUFVx1w8i1MBF4XH4PsAjKjQ1eqN/uCH3YKwP21GCKfrn6YZFZswbOk9+0cw1zGQPHVc1KBlSxig==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0",
+        "regexpu-core": "^4.1.3"
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0.tgz",
+      "integrity": "sha512-w2vfPkMqRkdxx+C71ATLJG30PpwtTpW7DDdLqYt2acXU7YjztzeWW2Jk1T6hKqCLYCcEA5UQM/+xTAm+QCSnuQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.1.0.tgz",
+      "integrity": "sha512-uZt9kD1Pp/JubkukOGQml9tqAeI8NkE98oZnHZ2qHRElmeKCodbTZgOEUtujSCSLhHSBWbzNiFSDIMC4/RBTLQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0.tgz",
+      "integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.1.0.tgz",
+      "integrity": "sha512-VxOa1TMlFMtqPW2IDYZQaHsFrq/dDoIjgN098NowhexhZcz3UGlvPgZXuE1jEvNygyWyxRacqDpCZt+par1FNg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0.tgz",
+      "integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.1.0.tgz",
+      "integrity": "sha512-wt8P+xQ85rrnGNr2x1iV3DW32W8zrB6ctuBkYBbf5/ZzJY99Ob4MFgsZDFgczNU76iy9PWsy4EuxOliDjdKw6A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.1.0.tgz",
+      "integrity": "sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-simple-access": "^7.1.0"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.1.3.tgz",
+      "integrity": "sha512-PvTxgjxQAq4pvVUZF3mD5gEtVDuId8NtWkJsZLEJZMZAW3TvgQl1pmydLLN1bM8huHFVVU43lf0uvjQj9FRkKw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.1.0.tgz",
+      "integrity": "sha512-enrRtn5TfRhMmbRwm7F8qOj0qEYByqUvTttPEGimcBH4CJHphjyK1Vg7sdU7JjeEmgSpM890IT/efS2nMHwYig==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz",
+      "integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.1.0.tgz",
+      "integrity": "sha512-/O02Je1CRTSk2SSJaq0xjwQ8hG4zhZGNjE8psTsSNPXyLRCODv7/PBozqT5AmQMzp7MI3ndvMhGdqp9c96tTEw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.1.0"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.1.0.tgz",
+      "integrity": "sha512-vHV7oxkEJ8IHxTfRr3hNGzV446GAb+0hgbA7o/0Jd76s+YzccdWuTU296FOCOl/xweU4t/Ya4g41yWz80RFCRw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-call-delegate": "^7.1.0",
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
+      "integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.13.3"
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz",
+      "integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0.tgz",
+      "integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0.tgz",
+      "integrity": "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0.tgz",
+      "integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0.tgz",
+      "integrity": "sha512-1r1X5DO78WnaAIvs5uC48t41LLckxsYklJrZjNKcevyz83sF2l4RHbw29qrCPr/6ksFsdfRpT/ZgxNWHXRnffg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0.tgz",
+      "integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0",
+        "regexpu-core": "^4.1.3"
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.6.tgz",
+      "integrity": "sha512-YIBfpJNQMBkb6MCkjz/A9J76SNCSuGVamOVBgoUkLzpJD/z8ghHi9I42LQ4pulVX68N/MmImz6ZTixt7Azgexw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.1.0",
+        "@babel/plugin-proposal-json-strings": "^7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.0.0",
+        "@babel/plugin-syntax-async-generators": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.0.0",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0",
+        "@babel/plugin-transform-async-to-generator": "^7.1.0",
+        "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+        "@babel/plugin-transform-block-scoping": "^7.1.5",
+        "@babel/plugin-transform-classes": "^7.1.0",
+        "@babel/plugin-transform-computed-properties": "^7.0.0",
+        "@babel/plugin-transform-destructuring": "^7.0.0",
+        "@babel/plugin-transform-dotall-regex": "^7.0.0",
+        "@babel/plugin-transform-duplicate-keys": "^7.0.0",
+        "@babel/plugin-transform-exponentiation-operator": "^7.1.0",
+        "@babel/plugin-transform-for-of": "^7.0.0",
+        "@babel/plugin-transform-function-name": "^7.1.0",
+        "@babel/plugin-transform-literals": "^7.0.0",
+        "@babel/plugin-transform-modules-amd": "^7.1.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.1.0",
+        "@babel/plugin-transform-modules-systemjs": "^7.0.0",
+        "@babel/plugin-transform-modules-umd": "^7.1.0",
+        "@babel/plugin-transform-new-target": "^7.0.0",
+        "@babel/plugin-transform-object-super": "^7.1.0",
+        "@babel/plugin-transform-parameters": "^7.1.0",
+        "@babel/plugin-transform-regenerator": "^7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+        "@babel/plugin-transform-spread": "^7.0.0",
+        "@babel/plugin-transform-sticky-regex": "^7.0.0",
+        "@babel/plugin-transform-template-literals": "^7.0.0",
+        "@babel/plugin-transform-typeof-symbol": "^7.0.0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0",
+        "browserslist": "^4.1.0",
+        "invariant": "^2.2.2",
+        "js-levenshtein": "^1.1.3",
+        "semver": "^5.3.0"
+      }
+    },
+    "@babel/template": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
+      "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.1.2",
+        "@babel/types": "^7.1.2"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.6.tgz",
+      "integrity": "sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.1.6",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/parser": "^7.1.6",
+        "@babel/types": "^7.1.6",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.6.tgz",
+      "integrity": "sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.10",
+        "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "esutils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
+    "CSSselect": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.7.0.tgz",
+      "integrity": "sha1-5AVMZ7RnRl88lQDA2gqnh4xLq9I=",
+      "requires": {
+        "CSSwhat": "0.4",
+        "boolbase": "~1.0.0",
+        "domutils": "1.4",
+        "nth-check": "~1.0.0"
+      }
+    },
+    "CSSwhat": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz",
+      "integrity": "sha1-hn2g/zn3eGEyQsRM/qg/CqTr35s="
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
+    "accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "dev": true,
+      "requires": {
+        "mime-types": "~2.1.18",
+        "negotiator": "0.6.1"
+      }
+    },
+    "after": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
+      "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "optional": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "anymatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "dev": true,
+      "requires": {
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+          "dev": true
+        }
+      }
+    },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-differ": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+      "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-slice": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+      "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+      "dev": true
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "arraybuffer.slice": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "async-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "dev": true
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true,
+      "optional": true
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true,
+      "optional": true
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true,
+      "optional": true
+    },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "base64-arraybuffer": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+      "dev": true
+    },
+    "base64id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "better-assert": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+      "dev": true,
+      "requires": {
+        "callsite": "1.0.0"
+      }
+    },
+    "binary-extensions": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
+      "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
+      "dev": true
+    },
+    "blob": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
+      "dev": true
+    },
+    "bluebird": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+      "dev": true
+    },
+    "body": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/body/-/body-5.1.0.tgz",
+      "integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
+      "dev": true,
+      "requires": {
+        "continuable-cache": "^0.3.1",
+        "error": "^7.0.0",
+        "raw-body": "~1.1.0",
+        "safe-json-parse": "~1.0.1"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+          "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
+          "dev": true
+        },
+        "raw-body": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
+          "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
+          "dev": true,
+          "requires": {
+            "bytes": "1",
+            "string_decoder": "0.10"
+          }
+        }
+      }
+    },
+    "body-parser": {
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
+        "iconv-lite": "0.4.23",
+        "on-finished": "~2.3.0",
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "~1.6.16"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.23",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
+        }
+      }
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "browserslist": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
+      "integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30000899",
+        "electron-to-chromium": "^1.3.82",
+        "node-releases": "^1.0.1"
+      }
+    },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "dev": true,
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "dev": true
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true,
+      "optional": true
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "dev": true
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
+    },
+    "callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000911",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000911.tgz",
+      "integrity": "sha512-x/E/SNwD80I0bT+fF9Y3Kbwo7Xd1xSafCAmFlpJmaVg3SQoJJOH4Ivb9fi9S0WjfqewQ6Ydt1zEVZpmMVYNeDA==",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true,
+      "optional": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "cheerio": {
+      "version": "0.12.4",
+      "resolved": "http://registry.npmjs.org/cheerio/-/cheerio-0.12.4.tgz",
+      "integrity": "sha1-wZlibp4esNQjOpGkeT5/iqppoYs=",
+      "requires": {
+        "cheerio-select": "*",
+        "entities": "0.x",
+        "htmlparser2": "3.1.4",
+        "underscore": "~1.4"
+      }
+    },
+    "cheerio-select": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-0.0.3.tgz",
+      "integrity": "sha1-PyQgEU88ywsbB1wkXM+q5dYXo4g=",
+      "requires": {
+        "CSSselect": "0.x"
+      }
+    },
+    "chokidar": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
+      "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+      "dev": true,
+      "requires": {
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.0",
+        "braces": "^2.3.0",
+        "fsevents": "^1.2.2",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "lodash.debounce": "^4.0.8",
+        "normalize-path": "^2.1.1",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0",
+        "upath": "^1.0.5"
+      }
+    },
+    "circular-json": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.9.tgz",
+      "integrity": "sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ==",
+      "dev": true
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "^7.1.1"
+      }
+    },
+    "coffeescript": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.10.0.tgz",
+      "integrity": "sha1-56qDAZF+9iGzXYo580jc3R234z4=",
+      "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "dev": true
+    },
+    "combine-lists": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/combine-lists/-/combine-lists-1.0.1.tgz",
+      "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.5.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "component-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
+      "dev": true
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
+    },
+    "component-inherit": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true,
+          "optional": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "connect": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+      "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.0",
+        "parseurl": "~1.3.2",
+        "utils-merge": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "^0.1.4"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true
+    },
+    "continuable-cache": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
+      "integrity": "sha1-vXJ6f67XfnH/OYWskzUakSczrQ8=",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "dev": true
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
+    },
+    "custom-event": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
+      "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
+      "dev": true
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+      "dev": true,
+      "optional": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "date-format": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-1.2.0.tgz",
+      "integrity": "sha1-YV6CjiM90aubua4JUODOzPpuytg=",
+      "dev": true
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
+    },
+    "dateformat": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+      "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1",
+        "meow": "^3.3.0"
+      }
+    },
+    "debug": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
+    "di": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
+      "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
+      "dev": true
+    },
+    "dom-serialize": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
+      "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
+      "dev": true,
+      "requires": {
+        "custom-event": "~1.0.0",
+        "ent": "~2.2.0",
+        "extend": "^3.0.0",
+        "void-elements": "^2.0.0"
+      }
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
+        },
+        "entities": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.2.1.tgz",
+      "integrity": "sha512-SQVCLFS2E7G5CRCMdn6K9bIhRj1bS6QBWZfF0TUPh4V/BbqrQ619IdSS3/izn0FZ+9l+uODzaZjb08fjOfablA=="
+    },
+    "domhandler": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.0.3.tgz",
+      "integrity": "sha1-iJ+N9iZAOvB4jinWbV1cb36/D9Y=",
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+      "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.3.85",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.85.tgz",
+      "integrity": "sha512-kWSDVVF9t3mft2OHVZy4K85X2beP6c6mFm3teFS/mLSDJpQwuFIWHrULCX+w6H1E55ZYmFRlT+ATAFRwhrYzsw==",
+      "dev": true
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true
+    },
+    "engine.io": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.1.tgz",
+      "integrity": "sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.4",
+        "base64id": "1.0.0",
+        "cookie": "0.3.1",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.0",
+        "ws": "~3.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "engine.io-client": {
+      "version": "3.2.1",
+      "resolved": "http://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+      "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1",
+        "component-inherit": "0.0.3",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.1",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "ws": "~3.3.1",
+        "xmlhttprequest-ssl": "~1.5.4",
+        "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+      "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
+      "dev": true,
+      "requires": {
+        "after": "0.8.2",
+        "arraybuffer.slice": "~0.0.7",
+        "base64-arraybuffer": "0.1.5",
+        "blob": "0.0.5",
+        "has-binary2": "~1.0.2"
+      }
+    },
+    "ent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
+      "dev": true
+    },
+    "entities": {
+      "version": "0.5.0",
+      "resolved": "http://registry.npmjs.org/entities/-/entities-0.5.0.tgz",
+      "integrity": "sha1-9hHLWuIhBQ4AEsZpeVA/164ZzEk="
+    },
+    "error": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
+      "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
+      "dev": true,
+      "requires": {
+        "string-template": "~0.2.1",
+        "xtend": "~4.0.0"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
+      "dev": true,
+      "optional": true
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "escodegen": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+      "integrity": "sha1-Nn3hfYUQVA0SvG3Liz+Rg5EmWBU=",
+      "requires": {
+        "esprima": "^1.2.2",
+        "estraverse": "^1.9.1",
+        "esutils": "^1.1.6",
+        "optionator": "^0.5.0",
+        "source-map": "~0.1.40"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+          "integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek="
+        }
+      }
+    },
+    "escope": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-1.0.3.tgz",
+      "integrity": "sha1-dZ3OhJbEJI/sLQyq9BCLzz8af10=",
+      "requires": {
+        "estraverse": "^2.0.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz",
+          "integrity": "sha1-WuRpYyQ2ACBmdMyySgnhZnT83KE="
+        }
+      }
+    },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true
+    },
+    "estraverse": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
+    },
+    "esutils": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+      "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U="
+    },
+    "eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+      "dev": true
+    },
+    "eventemitter3": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
+      "dev": true
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "expand-braces": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
+      "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
+      "dev": true,
+      "requires": {
+        "array-slice": "^0.2.3",
+        "array-unique": "^0.2.1",
+        "braces": "^0.1.2"
+      },
+      "dependencies": {
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true
+        },
+        "braces": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
+          "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
+          "dev": true,
+          "requires": {
+            "expand-range": "^0.1.0"
+          }
+        }
+      }
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "expand-range": {
+      "version": "0.1.1",
+      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
+      "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
+      "dev": true,
+      "requires": {
+        "is-number": "^0.1.1",
+        "repeat-string": "^0.2.2"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz",
+          "integrity": "sha1-aaevEWlj1HIG7JvZtIoUIW8eOAY=",
+          "dev": true
+        },
+        "repeat-string": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz",
+          "integrity": "sha1-x6jTI2BoNiBZp+RlH8aITosftK4=",
+          "dev": true
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "extract-zip": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "yauzl": "2.4.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+      "dev": true,
+      "optional": true
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true,
+      "optional": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true,
+      "optional": true
+    },
+    "fast-levenshtein": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+      "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk="
+    },
+    "faye-websocket": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+      "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+      "dev": true,
+      "requires": {
+        "websocket-driver": ">=0.5.1"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "dev": true
+        }
+      }
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dev": true,
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true,
+      "optional": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
+    "fs-extra": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+      "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.21",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": "^2.1.0"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
+    "gaze": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+      "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+      "dev": true,
+      "requires": {
+        "globule": "^1.0.0"
+      }
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
+    "getobject": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+      "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        }
+      }
+    },
+    "globals": {
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
+      "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
+      "dev": true
+    },
+    "globule": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
+      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+      "dev": true,
+      "requires": {
+        "glob": "~7.1.1",
+        "lodash": "~4.17.10",
+        "minimatch": "~3.0.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
+    },
+    "grunt": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.3.tgz",
+      "integrity": "sha512-/JzmZNPfKorlCrrmxWqQO4JVodO+DVd5XX4DkocL/1WlLlKVLE9+SdEIempOAxDhWPysLle6afvn/hg7Ck2k9g==",
+      "dev": true,
+      "requires": {
+        "coffeescript": "~1.10.0",
+        "dateformat": "~1.0.12",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.3.0",
+        "glob": "~7.0.0",
+        "grunt-cli": "~1.2.0",
+        "grunt-known-options": "~1.1.0",
+        "grunt-legacy-log": "~2.0.0",
+        "grunt-legacy-util": "~1.1.1",
+        "iconv-lite": "~0.4.13",
+        "js-yaml": "~3.5.2",
+        "minimatch": "~3.0.2",
+        "mkdirp": "~0.5.1",
+        "nopt": "~3.0.6",
+        "path-is-absolute": "~1.0.0",
+        "rimraf": "~2.6.2"
+      },
+      "dependencies": {
+        "findup-sync": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+          "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+          "dev": true,
+          "requires": {
+            "glob": "~5.0.0"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "dev": true,
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+          "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "grunt-cli": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
+          "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
+          "dev": true,
+          "requires": {
+            "findup-sync": "~0.3.0",
+            "grunt-known-options": "~1.1.0",
+            "nopt": "~3.0.6",
+            "resolve": "~1.1.0"
+          }
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        }
+      }
+    },
+    "grunt-contrib-clean": {
+      "version": "0.6.0",
+      "resolved": "http://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.6.0.tgz",
+      "integrity": "sha1-9TLbpLghJnTHwBPhRr2mY4uQSPY=",
+      "dev": true,
+      "requires": {
+        "rimraf": "~2.2.1"
+      }
+    },
+    "grunt-contrib-concat": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-0.4.0.tgz",
+      "integrity": "sha1-uH988VO/ZGiBQvlHFhFWAT+8fHQ=",
+      "dev": true,
+      "requires": {
+        "chalk": "~0.4.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "0.4.0",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "~1.0.0",
+            "has-color": "~0.1.0",
+            "strip-ansi": "~0.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "0.1.1",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-contrib-copy": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.5.0.tgz",
+      "integrity": "sha1-QQB1rEWlhWuhkbHMclclRQ1KAhU=",
+      "dev": true
+    },
+    "grunt-contrib-jshint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-2.0.0.tgz",
+      "integrity": "sha512-4qR411I1bhvVrPkKBzCUcrWkTEtBuWioXi9ABWRXHoplRScg03jiMqLDpzS4pDhVsLOTx5F9l+0cnMc+Gd2MWg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "hooker": "^0.2.3",
+        "jshint": "~2.9.6"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "grunt-contrib-watch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-1.1.0.tgz",
+      "integrity": "sha512-yGweN+0DW5yM+oo58fRu/XIRrPcn3r4tQx+nL7eMRwjpvk+rQY6R8o94BPK0i2UhTg9FN21hS+m8vR8v9vXfeg==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.0",
+        "gaze": "^1.1.0",
+        "lodash": "^4.17.10",
+        "tiny-lr": "^1.1.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
+    "grunt-karma": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-karma/-/grunt-karma-3.0.1.tgz",
+      "integrity": "sha512-iNt1Qe5GoePMIfBQmeffvfrvnvwTfJ9/h9p9gqGMIuEdVsUo4PKhTxIwyW5NMbHrgD8p2UEdeTJH4l0QGz4YtA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
+    "grunt-known-options": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.1.tgz",
+      "integrity": "sha512-cHwsLqoighpu7TuYj5RonnEuxGVFnztcUqTqp5rXFGYL4OuPFofwC4Ycg7n9fYwvK6F5WbYgeVOwph9Crs2fsQ==",
+      "dev": true
+    },
+    "grunt-legacy-log": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-2.0.0.tgz",
+      "integrity": "sha512-1m3+5QvDYfR1ltr8hjiaiNjddxGdQWcH0rw1iKKiQnF0+xtgTazirSTGu68RchPyh1OBng1bBUjLmX8q9NpoCw==",
+      "dev": true,
+      "requires": {
+        "colors": "~1.1.2",
+        "grunt-legacy-log-utils": "~2.0.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.17.5"
+      }
+    },
+    "grunt-legacy-log-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-2.0.1.tgz",
+      "integrity": "sha512-o7uHyO/J+i2tXG8r2bZNlVk20vlIFJ9IEYyHMCQGfWYru8Jv3wTqKZzvV30YW9rWEjq0eP3cflQ1qWojIe9VFA==",
+      "dev": true,
+      "requires": {
+        "chalk": "~2.4.1",
+        "lodash": "~4.17.10"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "grunt-legacy-util": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.1.1.tgz",
+      "integrity": "sha512-9zyA29w/fBe6BIfjGENndwoe1Uy31BIXxTH3s8mga0Z5Bz2Sp4UCjkeyv2tI449ymkx3x26B+46FV4fXEddl5A==",
+      "dev": true,
+      "requires": {
+        "async": "~1.5.2",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.17.10",
+        "underscore.string": "~3.3.4",
+        "which": "~1.3.0"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true,
+      "optional": true
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-binary2": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+      "dev": true,
+      "requires": {
+        "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
+        }
+      }
+    },
+    "has-color": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+      "dev": true
+    },
+    "has-cors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "hasha": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+      "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "is-stream": "^1.0.1",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "hooker": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.1.4",
+      "resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.1.4.tgz",
+      "integrity": "sha1-csvn1dVsAaz2H897kzMx9ORbNvA=",
+      "requires": {
+        "domelementtype": "1",
+        "domhandler": "2.0",
+        "domutils": "1.1",
+        "readable-stream": "1.0"
+      },
+      "dependencies": {
+        "domutils": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
+          "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
+          "requires": {
+            "domelementtype": "1"
+          }
+        }
+      }
+    },
+    "http-errors": {
+      "version": "1.6.3",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "dev": true,
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      }
+    },
+    "http-parser-js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.0.tgz",
+      "integrity": "sha512-cZdEF7r4gfRIq7ezX9J0T+kQmJNOub71dWbgAXVHDct80TKP4MCETtZQ31xyv38UwgzkWPYF/Xc0ge55dW9Z9w==",
+      "dev": true
+    },
+    "http-proxy": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+      "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^3.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^1.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^1.0.0"
+      }
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-glob": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true,
+      "optional": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true,
+      "optional": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "isbinaryfile": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
+      "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
+      "dev": true,
+      "requires": {
+        "buffer-alloc": "^1.2.0"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "js-levenshtein": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.4.tgz",
+      "integrity": "sha512-PxfGzSs0ztShKrUYPIn5r0MtyAhYcCwmndozzpz8YObbPnD1jFxzlBGbRnX2mIu6Z13xN6+PTu05TQFnZFlzow==",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
+      "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.2",
+        "esprima": "^2.6.0"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
+    "jshint": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.6.tgz",
+      "integrity": "sha512-KO9SIAKTlJQOM4lE64GQUtGBRpTOuvbrRrSZw3AhUxMNG266nX9hK2cKA4SBhXOj0irJGyNyGSLT62HGOVDEOA==",
+      "dev": true,
+      "requires": {
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "~4.17.10",
+        "minimatch": "~3.0.2",
+        "phantom": "~4.0.1",
+        "phantomjs-prebuilt": "~2.1.7",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x",
+        "unicode-5.2.0": "^0.7.5"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+          "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "domutils": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+          "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "0",
+            "domelementtype": "1"
+          }
+        },
+        "entities": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+          "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+          "dev": true
+        },
+        "htmlparser2": {
+          "version": "3.8.3",
+          "resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1",
+            "domhandler": "2.3",
+            "domutils": "1.5",
+            "entities": "1.0",
+            "readable-stream": "1.1"
+          }
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        }
+      }
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true,
+      "optional": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "optional": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true,
+      "optional": true
+    },
+    "json5": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+      "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      }
+    },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "karma": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-3.1.1.tgz",
+      "integrity": "sha512-NetT3wPCQMNB36uiL9LLyhrOt8SQwrEKt0xD3+KpTCfm0VxVyUJdPL5oTq2Ic5ouemgL/Iz4wqXEbF3zea9kQQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.3.0",
+        "body-parser": "^1.16.1",
+        "chokidar": "^2.0.3",
+        "colors": "^1.1.0",
+        "combine-lists": "^1.0.0",
+        "connect": "^3.6.0",
+        "core-js": "^2.2.0",
+        "di": "^0.0.1",
+        "dom-serialize": "^2.2.0",
+        "expand-braces": "^0.1.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.2",
+        "http-proxy": "^1.13.0",
+        "isbinaryfile": "^3.0.0",
+        "lodash": "^4.17.4",
+        "log4js": "^3.0.0",
+        "mime": "^2.3.1",
+        "minimatch": "^3.0.2",
+        "optimist": "^0.6.1",
+        "qjobs": "^1.1.4",
+        "range-parser": "^1.2.0",
+        "rimraf": "^2.6.0",
+        "safe-buffer": "^5.0.1",
+        "socket.io": "2.1.1",
+        "source-map": "^0.6.1",
+        "tmp": "0.0.33",
+        "useragent": "2.2.1"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
+          "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "dev": true,
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "karma-chrome-launcher": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.1.4.tgz",
+      "integrity": "sha1-SS9rjO7T2suCmxR1FMkQZmDxsYU=",
+      "dev": true
+    },
+    "karma-firefox-launcher": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-0.1.3.tgz",
+      "integrity": "sha1-iMigb1Xeu+ZPjKSx9osLih875RQ=",
+      "dev": true
+    },
+    "karma-jasmine": {
+      "version": "0.2.2",
+      "resolved": "http://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.2.2.tgz",
+      "integrity": "sha1-36xYWRMcIzwxDH4LAX906+Mlmkg=",
+      "dev": true
+    },
+    "kew": {
+      "version": "0.7.0",
+      "resolved": "http://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
+      "dev": true,
+      "optional": true
+    },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
+    },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
+    "levn": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+      "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
+      "requires": {
+        "prelude-ls": "~1.1.0",
+        "type-check": "~0.3.1"
+      }
+    },
+    "livereload-js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.4.0.tgz",
+      "integrity": "sha512-XPQH8Z2GDP/Hwz2PCDrh2mth4yFejwA1OZ/81Ti3LgKyhDcEjsSsqFWZojHG0va/duGd+WyosY7eXLDoOyqcPw==",
+      "dev": true
+    },
+    "load-grunt-tasks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-4.0.0.tgz",
+      "integrity": "sha512-w5JYPHpZgMxu9XFR9N9MEzyX8E0mLhQkwQ1qVP4mb3gmuomw8Ww8J49NHMbXqyQliq2LUCqdU7/wW96IVuPCKw==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.0",
+        "multimatch": "^2.0.0",
+        "pkg-up": "^2.0.0",
+        "resolve-pkg": "^1.0.0"
+      }
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
+    "log4js": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-3.0.6.tgz",
+      "integrity": "sha512-ezXZk6oPJCWL483zj64pNkMuY/NcRX5MPiB0zE6tjZM137aeusrOnW1ecxgF9cmwMWkBMhjteQxBPoZBh9FDxQ==",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.5.5",
+        "date-format": "^1.2.0",
+        "debug": "^3.1.0",
+        "rfdc": "^1.1.2",
+        "streamroller": "0.7.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
+      }
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      }
+    },
+    "mime": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "dev": true,
+      "requires": {
+        "mime-db": "~1.37.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true
+    },
+    "multimatch": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+      "dev": true,
+      "requires": {
+        "array-differ": "^1.0.0",
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "minimatch": "^3.0.0"
+      }
+    },
+    "nan": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "dev": true,
+      "optional": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+      "dev": true
+    },
+    "node-releases": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.4.tgz",
+      "integrity": "sha512-GqRV9GcHw8JCRDaP/JoeNMNzEGzHAknMvIHqMb2VeTOmg1Cf9+ej8bkV12tHfzWHQMCkQ5zUFgwFUkfraynNCw==",
+      "dev": true,
+      "requires": {
+        "semver": "^5.3.0"
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
+      }
+    },
+    "nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "requires": {
+        "boolbase": "~1.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true,
+      "optional": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-component": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
+      "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "optimist": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+      "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+      "requires": {
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "optionator": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+      "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
+      "requires": {
+        "deep-is": "~0.1.2",
+        "fast-levenshtein": "~1.0.0",
+        "levn": "~0.2.5",
+        "prelude-ls": "~1.1.1",
+        "type-check": "~0.3.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
+    "parseqs": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+      "dev": true,
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
+    },
+    "parseuri": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+      "dev": true,
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+      "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true,
+      "optional": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true,
+      "optional": true
+    },
+    "phantom": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/phantom/-/phantom-4.0.12.tgz",
+      "integrity": "sha512-Tz82XhtPmwCk1FFPmecy7yRGZG2btpzY2KI9fcoPT7zT9det0CcMyfBFPp1S8DqzsnQnm8ZYEfdy528mwVtksA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "phantomjs-prebuilt": "^2.1.16",
+        "split": "^1.0.1",
+        "winston": "^2.4.0"
+      }
+    },
+    "phantomjs-prebuilt": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
+      "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "es6-promise": "^4.0.3",
+        "extract-zip": "^1.6.5",
+        "fs-extra": "^1.0.0",
+        "hasha": "^2.2.0",
+        "kew": "^0.7.0",
+        "progress": "^1.1.8",
+        "request": "^2.81.0",
+        "request-progress": "^2.0.1",
+        "which": "^1.2.10"
+      }
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        }
+      }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+    },
+    "prettier": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.2.tgz",
+      "integrity": "sha512-YgPLFFA0CdKL4Eg2IHtUSjzj/BWgszDHiNQAe0VAIBse34148whfdzLagRL+QiKS+YfK5ftB6X4v/MBw8yCoug=="
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "progress": {
+      "version": "1.1.8",
+      "resolved": "http://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "dev": true,
+      "optional": true
+    },
+    "psl": {
+      "version": "1.1.29",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+      "dev": true,
+      "optional": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
+      "optional": true
+    },
+    "qjobs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.2.0.tgz",
+      "integrity": "sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
+      "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA==",
+      "dev": true
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "dev": true
+    },
+    "raw-body": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.23",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
+      }
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "1.0.34",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "readdirp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      }
+    },
+    "regenerate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+      "dev": true
+    },
+    "regenerate-unicode-properties": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
+      "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0"
+      }
+    },
+    "regenerator-transform": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
+      "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
+      "dev": true,
+      "requires": {
+        "private": "^0.1.6"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "regexpu-core": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
+      "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^7.0.0",
+        "regjsgen": "^0.4.0",
+        "regjsparser": "^0.3.0",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.0.2"
+      }
+    },
+    "regjsgen": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
+      "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
+      "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
+    },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "request-progress": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+      "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "throttleit": "^1.0.0"
+      }
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+      "integrity": "sha1-3ZV5gufnNt699TtYpN2RdUV13UY="
+    },
+    "resolve-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+      "dev": true
+    },
+    "resolve-pkg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-1.0.0.tgz",
+      "integrity": "sha1-4ZoV54rKLhJEYdySsuOUPvk0lNk=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^2.0.0"
+      }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "rfdc": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.2.tgz",
+      "integrity": "sha512-92ktAgvZhBzYTIK0Mja9uen5q5J3NRVMoDkJL2VMwq6SXjVCgqvQeVP2XAaUY6HT+XpQYeLSjb3UoitBryKmdA==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.2.8",
+      "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safe-json-parse": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
+      "integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true
+    },
+    "shelljs": {
+      "version": "0.3.0",
+      "resolved": "http://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "socket.io": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
+      "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
+      "dev": true,
+      "requires": {
+        "debug": "~3.1.0",
+        "engine.io": "~3.2.0",
+        "has-binary2": "~1.0.2",
+        "socket.io-adapter": "~1.1.0",
+        "socket.io-client": "2.1.1",
+        "socket.io-parser": "~3.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "socket.io-adapter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
+      "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs=",
+      "dev": true
+    },
+    "socket.io-client": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
+      "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+      "dev": true,
+      "requires": {
+        "backo2": "1.0.2",
+        "base64-arraybuffer": "0.1.5",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.1",
+        "debug": "~3.1.0",
+        "engine.io-client": "~3.2.0",
+        "has-binary2": "~1.0.2",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "socket.io-parser": "~3.2.0",
+        "to-array": "0.1.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "socket.io-parser": {
+      "version": "3.2.0",
+      "resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+      "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1",
+        "debug": "~3.1.0",
+        "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.1.43",
+      "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+      "optional": true,
+      "requires": {
+        "amdefine": ">=0.0.4"
+      }
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
+      "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
+      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
+      "dev": true
+    },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "through": "2"
+      }
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
+      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true,
+      "optional": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "dev": true
+    },
+    "streamroller": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.7.0.tgz",
+      "integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
+      "dev": true,
+      "requires": {
+        "date-format": "^1.2.0",
+        "debug": "^3.1.0",
+        "mkdirp": "^0.5.1",
+        "readable-stream": "^2.3.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "string-template": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+      "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "sweet.js": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/sweet.js/-/sweet.js-0.7.8.tgz",
+      "integrity": "sha1-+gSc+RsyEGqaDOhWwXMt6Q3i7bM=",
+      "requires": {
+        "escodegen": "1.6.x",
+        "escope": "1.0.x",
+        "optimist": "~0.3.4",
+        "resolve": "~0.6.1",
+        "underscore": "~1.3.3"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.3.3.tgz",
+          "integrity": "sha1-R6xTaD2vgyv6lS4XdEF9pHgXrkI="
+        }
+      }
+    },
+    "throttleit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
+      "dev": true,
+      "optional": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true,
+      "optional": true
+    },
+    "tiny-lr": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
+      "integrity": "sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==",
+      "dev": true,
+      "requires": {
+        "body": "^5.1.0",
+        "debug": "^3.1.0",
+        "faye-websocket": "~0.10.0",
+        "livereload-js": "^2.3.0",
+        "object-assign": "^4.1.0",
+        "qs": "^6.4.0"
+      }
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "to-array": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "type-is": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.18"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true,
+      "optional": true
+    },
+    "uglify-js": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+      "requires": {
+        "commander": "~2.17.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
+    "ultron": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+    },
+    "underscore.string": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
+      "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "^1.0.3",
+        "util-deprecate": "^1.0.2"
+      }
+    },
+    "unicode-5.2.0": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/unicode-5.2.0/-/unicode-5.2.0-0.7.5.tgz",
+      "integrity": "sha512-KVGLW1Bri30x00yv4HNM8kBxoqFXr0Sbo55735nvrlsx4PYBZol3UtoWgO492fSwmsetzPEZzy73rbU8OGXJcA==",
+      "dev": true
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
+      "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
+      "dev": true
+    },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
+          }
+        }
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        }
+      }
+    },
+    "upath": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
+      "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
+    },
+    "useragent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.2.1.tgz",
+      "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2.2.x",
+        "tmp": "0.0.x"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "2.2.4",
+          "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
+          "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=",
+          "dev": true
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true,
+      "optional": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "void-elements": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
+      "dev": true
+    },
+    "websocket-driver": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+      "dev": true,
+      "requires": {
+        "http-parser-js": ">=0.4.0",
+        "websocket-extensions": ">=0.1.1"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+      "dev": true
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "winston": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
+      "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "async": "~1.0.0",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "stack-trace": "0.0.x"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+          "dev": true,
+          "optional": true
+        },
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "ws": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "dev": true,
+      "requires": {
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
+      }
+    },
+    "xmlhttprequest-ssl": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "fd-slicer": "~1.0.1"
+      }
+    },
+    "yeast": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-spiritual-edbml",
   "description": "Compile EDBML",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "dependencies": {
     "chalk": "^1.0.0",
     "cheerio": "~0.12.3",

--- a/package.json
+++ b/package.json
@@ -5,23 +5,25 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "cheerio": "~0.12.3",
-    "esformatter": "0.0.6",
-    "uglify-js": "~2.4.0",
-    "sweet.js": "^0.7.1"
+    "prettier": "1.15.2",
+    "sweet.js": "^0.7.1",
+    "uglify-js": "~3.4.9"
   },
   "devDependencies": {
-    "6to5": "^1.13.2",
-    "grunt": "^0.4.4",
+    "@babel/core": "^7.1.6",
+    "@babel/preset-env": "^7.1.6",
+    "grunt": "^1.0.3",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-concat": "^0.4.0",
     "grunt-contrib-copy": "^0.5.0",
-    "grunt-contrib-jshint": "^0.10.0",
-    "grunt-contrib-watch": "^0.6.1",
-    "grunt-karma": "0.9.0",
+    "grunt-contrib-jshint": "^2.0.0",
+    "grunt-contrib-watch": "^1.1.0",
+    "grunt-karma": "3.0.1",
+    "karma": "^3.1.1",
     "karma-chrome-launcher": "0.1.4",
     "karma-firefox-launcher": "0.1.3",
     "karma-jasmine": "0.2.2",
-    "load-grunt-tasks": "^0.6.0"
+    "load-grunt-tasks": "^4.0.0"
   },
   "repository": {
     "type": "git",

--- a/src/compilers/Compiler.js
+++ b/src/compilers/Compiler.js
@@ -1,11 +1,10 @@
-"use strict";
+'use strict';
 
 /**
  * Base compiler.
  * Note to self: Conceptualize peek|poke|geek|passout|lockout
  */
 class Compiler {
-
 	/**
 	 * Let's go.
 	 */
@@ -23,7 +22,7 @@ class Compiler {
 	 */
 	newline(line, runner, status, markup, output) {
 		status.last = line.length - 1;
-		status.adds = line[0] === "+";
+		status.adds = line[0] === '+';
 		status.cont = status.cont || (status.ishtml() && status.adds);
 	}
 
@@ -42,7 +41,7 @@ class Compiler {
 				status.gojs();
 			}
 		} else {
-			output.body += "\n";
+			output.body += '\n';
 		}
 		status.cont = false;
 	}
@@ -78,7 +77,6 @@ class Compiler {
 		}
 	}
 
-
 	// Private ...................................................................
 
 	/**
@@ -92,7 +90,7 @@ class Compiler {
 		var markup = new Markup();
 		var output = new Output();
 		runner.run(this, script, status, markup, output);
-		output.body += (status.ishtml() ? "';" : "") + "\nreturn out.write ();";
+		output.body += (status.ishtml() ? "';" : '') + '\nreturn out.write ();';
 		return output.body;
 	}
 
@@ -106,7 +104,7 @@ class Compiler {
 	 */
 	_compilejs(c, runner, status, markup, output) {
 		switch (c) {
-			case "<":
+			case '<':
 				if (runner.firstchar) {
 					status.gohtml();
 					markup.next(c);
@@ -114,7 +112,7 @@ class Compiler {
 					output.body += "out.html += '";
 				}
 				break;
-			case "@":
+			case '@':
 				// handled by the @ macro
 				break;
 		}
@@ -133,12 +131,12 @@ class Compiler {
 		if (!this._continueshtml(c, runner, status)) {
 			var context = markup.next(c);
 			switch (c) {
-				case "{":
+				case '{':
 					if (special) {
 						status.curl++;
 					}
 					break;
-				case "}":
+				case '}':
 					if (--status.curl === 0) {
 						if (status.peek) {
 							status.peek = false;
@@ -162,36 +160,37 @@ class Compiler {
 						}
 					}
 					break;
-				case "$":
-					if (!special && runner.ahead("{")) {
+				case '$':
+					if (!special && runner.ahead('{')) {
 						status.peek = true;
 						status.skip = 2;
 						status.curl = 0;
-						output.body += "' + " + this._escapefrom(context) + " (";
+						output.body +=
+							"' + " + this._escapefrom(context) + ' (';
 					}
 					break;
-				case "#":
-					if (!special && runner.ahead("{")) {
+				case '#':
+					if (!special && runner.ahead('{')) {
 						status.poke = true;
 						status.skip = 2;
 						status.curl = 0;
-						output.temp = "";
+						output.temp = '';
 					}
 					break;
-				case "?":
-					if (!special && runner.ahead("{")) {
+				case '?':
+					if (!special && runner.ahead('{')) {
 						status.geek = true;
 						status.skip = 2;
 						status.curl = 0;
-						output.temp = "";
+						output.temp = '';
 					}
 					break;
 				case "'":
 					if (!special) {
-						output.body += "\\";
+						output.body += '\\';
 					}
 					break;
-				case "@":
+				case '@':
 					this._htmlatt(runner, status, markup, output);
 					break;
 			}
@@ -207,7 +206,7 @@ class Compiler {
 	 * @returns {boolean}
 	 */
 	_continueshtml(c, runner, status) {
-		if (c === "+") {
+		if (c === '+') {
 			if (runner.firstchar) {
 				status.skip = status.adds ? 1 : 0;
 				return true;
@@ -247,17 +246,20 @@ class Compiler {
 	_htmlatt(runner, status, markup, output) {
 		var attr = Compiler._ATTREXP;
 		var rest, name, dels, what;
-		if (runner.behind("@")) {} else if (runner.behind("#{")) {
-			console.error("todo");
-		} else if (runner.ahead("@")) {
+		if (runner.behind('@')) {
+		} else if (runner.behind('#{')) {
+			console.error('todo');
+		} else if (runner.ahead('@')) {
 			output.body += "' + $att.$all() + '";
 			status.skip = 2;
 		} else {
 			rest = runner.lineahead();
 			name = attr.exec(rest)[0];
-			dels = runner.behind("-");
-			what = dels ? "$att.$pop" : "$att.$";
-			output.body = dels ? output.body.substring(0, output.body.length - 1) : output.body;
+			dels = runner.behind('-');
+			what = dels ? '$att.$pop' : '$att.$';
+			output.body = dels
+				? output.body.substring(0, output.body.length - 1)
+				: output.body;
 			output.body += "' + " + what + " ( '" + name + "' ) + '";
 			status.skip = name.length + 1;
 		}
@@ -273,8 +275,9 @@ class Compiler {
 		var tag = markup.tag || '';
 		var arg = tag.match(/input|textarea/) ? 'value, checked' : '';
 		this._injectcombo(status, markup, output, {
-			outline: "var $name = $set(function(" + arg + ") {\n$temp;\n}, this);",
-			inline: "edbml.$run(this, \\'\' + $name + \'\\');"
+			outline:
+				'var $name = $set(function(' + arg + ') {\n$temp;\n}, this);',
+			inline: "edbml.$run(this, \\'' + $name + '\\');"
 		});
 	}
 
@@ -286,8 +289,8 @@ class Compiler {
 	 */
 	_geek(status, markup, output) {
 		this._injectcombo(status, markup, output, {
-			outline: "var $name = $set(function() {\nreturn $temp;\n}, this);",
-			inline: "edbml.$get(&quot;\' + $name + \'&quot;);"
+			outline: 'var $name = $set(function() {\nreturn $temp;\n}, this);',
+			inline: "edbml.$get(&quot;' + $name + '&quot;);"
 		});
 	}
 
@@ -304,17 +307,13 @@ class Compiler {
 			spot = status.spot,
 			prev = body.substring(0, spot),
 			next = body.substring(spot),
-			name = '$' + (++this._keycounter);
-		var outl = combo.outline.replace("$name", name).replace("$temp", temp);
+			name = '$' + ++this._keycounter;
+		var outl = combo.outline.replace('$name', name).replace('$temp', temp);
 		output.body =
-			prev + "\n" +
-			outl +
-			next +
-			combo.inline.replace("$name", name);
+			prev + '\n' + outl + next + combo.inline.replace('$name', name);
 		status.spot += outl.length + 1;
 	}
 }
-
 
 // Static ......................................................................
 

--- a/src/compilers/FunctionCompiler.js
+++ b/src/compilers/FunctionCompiler.js
@@ -1,16 +1,14 @@
-"use strict";
+'use strict';
 
 /**
  * Function compiler.
  * @extends {Compiler}
  */
 class FunctionCompiler extends Compiler {
-
 	/**
 	 * Construction time again.
 	 */
 	constructor() {
-
 		super();
 
 		/**
@@ -92,7 +90,6 @@ class FunctionCompiler extends Compiler {
 		return new Result(source, this._params, this._instructions);
 	}
 
-
 	// Private ...................................................................
 
 	/**
@@ -112,7 +109,7 @@ class FunctionCompiler extends Compiler {
 	 */
 	_validate(script) {
 		if (FunctionCompiler._NESTEXP.test(script)) {
-			throw "Nested EDBML dysfunction";
+			throw 'Nested EDBML dysfunction';
 		}
 		return script;
 	}
@@ -132,7 +129,7 @@ class FunctionCompiler extends Compiler {
 	 * @returns {string}
 	 */
 	_extract(script) {
-		Instruction.from(script).forEach((pi) => {
+		Instruction.from(script).forEach(pi => {
 			this._instructions = this._instructions || [];
 			this._instructions.push(pi);
 			this._instruct(pi);
@@ -147,10 +144,10 @@ class FunctionCompiler extends Compiler {
 	_instruct(pi) {
 		var att = pi.att;
 		switch (pi.tag) {
-			case "param":
+			case 'param':
 				this._params.push(att.name);
 				break;
-			case "function":
+			case 'function':
 				this._functions[att.name] = att.src;
 				break;
 		}
@@ -158,7 +155,7 @@ class FunctionCompiler extends Compiler {
 
 	/**
 	 * Define stuff in head. Using var name underscore hack
-	 * to bypass the macro hygiene, will be normalized later. 
+	 * to bypass the macro hygiene, will be normalized later.
 	 * TODO: In string checks, also check for starting '('
 	 * @param {string} script
 	 * @param {object} head
@@ -168,19 +165,20 @@ class FunctionCompiler extends Compiler {
 		var head = this._head;
 		var params = this._params;
 		var functions = this._functions;
-		if (params.indexOf("out") < 0) {
-			head.out = "$edbml.$out__MACROFIX";
+		if (params.indexOf('out') < 0) {
+			head.out = '$edbml.$out__MACROFIX';
 		}
-		if(script.contains('@')) { // TODO: run macros FIRST at look for '$att' ???
+		if (script.contains('@')) {
+			// TODO: run macros FIRST at look for '$att' ???
 			head.$att__MACROFIX = '$edbml.$att__MACROFIX';
 		}
-		if(script.contains('$set')) {
+		if (script.contains('$set')) {
 			head.$set = 'edbml.$set';
 		}
-		if(script.contains('$txt')) {
+		if (script.contains('$txt')) {
 			head.$txt = 'edbml.safetext';
 		}
-		if(script.contains('$val')) {
+		if (script.contains('$val')) {
 			head.$val = 'edbml.safeattr';
 		}
 		each(functions, function(name, src) {
@@ -190,17 +188,22 @@ class FunctionCompiler extends Compiler {
 	}
 
 	/**
-	 * Inject stuff in head. Let's just hope that V8 keeps on iterating 
+	 * Inject stuff in head. Let's just hope that V8 keeps on iterating
 	 * object keys in chronological order (in which they were defined).
 	 * @param {string} script
 	 * @param {object} head
 	 * @returns {string}
 	 */
 	_injecthead(script, head) {
-		return "'use strict';\n" +
-			'var ' + each(this._head, (name, value) => {
+		return (
+			"'use strict';\n" +
+			'var ' +
+			each(this._head, (name, value) => {
 				return name + (value !== undefined ? ' = ' + value : '');
-			}).join(',') + ';' + script;
+			}).join(',') +
+			';' +
+			script
+		);
 	}
 
 	/**
@@ -219,12 +222,11 @@ class FunctionCompiler extends Compiler {
 	 * @returns {string}
 	 */
 	_source(source, params) {
-		var lines = source.split("\n");
+		var lines = source.split('\n');
 		lines.pop(); // empty line :/
-		var args = params.length ? "( " + params.join(", ") + " )" : "()";
-		return "function " + args + " {\n" + lines.join("\n") + "\n}";
+		var args = params.length ? '( ' + params.join(', ') + ' )' : '()';
+		return 'function ' + args + ' {\n' + lines.join('\n') + '\n}';
 	}
-
 }
 
 // Static ......................................................................

--- a/src/compilers/ScriptCompiler.js
+++ b/src/compilers/ScriptCompiler.js
@@ -1,11 +1,10 @@
-"use strict";
+'use strict';
 
 /**
  * Script compiler.
  * @extends {FunctionCompiler}
  */
 class ScriptCompiler extends FunctionCompiler {
-
 	/**
 	 * Map observed types.
 	 * Add custom sequence.
@@ -15,7 +14,6 @@ class ScriptCompiler extends FunctionCompiler {
 		super();
 		this.inputs = {};
 	}
-
 
 	// Private ...................................................................
 
@@ -28,7 +26,7 @@ class ScriptCompiler extends FunctionCompiler {
 		super._instruct(pi);
 		var atts = pi.att;
 		switch (pi.tag) {
-			case "input":
+			case 'input':
 				this.inputs[atts.name] = atts.type;
 				break;
 		}
@@ -42,10 +40,13 @@ class ScriptCompiler extends FunctionCompiler {
 	 */
 	_definehead(script) {
 		script = super._definehead(script);
-		each(this.inputs, (name, type) => {
-			this._head[name] = '$edbml.$input(' + type + ')';
-		}, this);
+		each(
+			this.inputs,
+			(name, type) => {
+				this._head[name] = '$edbml.$input(' + type + ')';
+			},
+			this
+		);
 		return script;
 	}
-
 }

--- a/src/footer.js
+++ b/src/footer.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 /**
  * @param {string} source
@@ -8,7 +8,7 @@
  * @returns {string}
  */
 exports.compile = function(edbml, options, macros, directives) {
-	if (edbml.contains("<?input")) {
+	if (edbml.contains('<?input')) {
 		return new ScriptCompiler().compile(edbml, options, macros, directives);
 	} else {
 		return new FunctionCompiler().compile(edbml, options, macros, directives);

--- a/src/header.js
+++ b/src/header.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 /**
  * Call function for each own key in object (exluding the prototype stuff)
@@ -8,7 +8,7 @@
  * @param @optional {object} thisp
  */
 function each(object, func, thisp) {
-	return Object.keys(object).map((key) => {
+	return Object.keys(object).map(key => {
 		return func.call(thisp, key, object[key]);
 	});
 }
@@ -23,12 +23,12 @@ function each(object, func, thisp) {
 function cast(string) {
 	var result = String(string);
 	switch (result) {
-		case "null":
+		case 'null':
 			result = null;
 			break;
-		case "true":
-		case "false":
-			result = (result === "true");
+		case 'true':
+		case 'false':
+			result = result === 'true';
 			break;
 		default:
 			if (String(parseInt(result, 10)) === result) {
@@ -38,7 +38,7 @@ function cast(string) {
 			}
 			break;
 	}
-	return result === "" ? true : result;
+	return result === '' ? true : result;
 }
 
 /**
@@ -50,7 +50,7 @@ var generateKey = (function() {
 	var keys = {};
 	return function() {
 		var ran = Math.random().toString();
-		var key = "key" + ran.slice(2, 11);
+		var key = 'key' + ran.slice(2, 11);
 		if (keys[key]) {
 			key = generateKey();
 		} else {
@@ -58,7 +58,7 @@ var generateKey = (function() {
 		}
 		return key;
 	};
-}());
+})();
 
 /**
  * What? This is wrong on so many.

--- a/src/helpers/Instruction.js
+++ b/src/helpers/Instruction.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 /**
  * EDB processing instruction.
@@ -6,14 +6,14 @@
  * @param {string} pi
  */
 class Instruction {
-
 	/**
 	 * @param {string} pi
 	 */
 	constructor(pi) {
-		this.tag = pi.split("<?")[1].split(" ")[0];
+		this.tag = pi.split('<?')[1].split(' ')[0];
 		this.att = Object.create(null);
-		var hit, atexp = Instruction._ATEXP;
+		var hit,
+			atexp = Instruction._ATEXP;
 		while ((hit = atexp.exec(pi))) {
 			var n = hit[1],
 				v = hit[2];
@@ -21,7 +21,6 @@ class Instruction {
 		}
 	}
 }
-
 
 // Static ......................................................................
 
@@ -45,7 +44,7 @@ Instruction.from = function(source) {
  * @returns {string}
  */
 Instruction.clean = function(source) {
-	return source.replace(this._PIEXP, "");
+	return source.replace(this._PIEXP, '');
 };
 
 /**

--- a/src/helpers/Markup.js
+++ b/src/helpers/Markup.js
@@ -1,13 +1,11 @@
-"use strict";
+'use strict';
 
 /**
- * Tracking the state of 
+ * Tracking the state of
  * markup while compiling.
  */
 class Markup {
-
 	constructor() {
-		
 		this.tag = null; // current tagname (if applicable)
 		this.att = null; // current attname (not maintained!)
 
@@ -20,8 +18,8 @@ class Markup {
 	}
 
 	next(c) {
-		this._index ++;
-		switch(c) {
+		this._index++;
+		switch (c) {
 			case '<':
 			case '>':
 				this._ontag(c);
@@ -45,14 +43,12 @@ class Markup {
 	}
 
 	/**
-	 * Log snapshots to console (for debugging purpose). 
-	 * You can call this method over in class Runner.js 
+	 * Log snapshots to console (for debugging purpose).
+	 * You can call this method over in class Runner.js
 	 */
 	debug() {
-		this._debug(this._snapshots);		
+		this._debug(this._snapshots);
 	}
-
-
 
 	// Private ...................................................................
 
@@ -61,16 +57,16 @@ class Markup {
 	 * @param {string} c
 	 */
 	_ontag(c) {
-		if(c === '<') {
-			if(this._is === 'txt') {
+		if (c === '<') {
+			if (this._is === 'txt') {
 				this.tag = null;
 				this._go('tag');
 			}
 		} else {
-			if(this._is === 'tag') {
+			if (this._is === 'tag') {
 				this.tag = this._buffer.trim();
 			}
-			switch(this._is) {
+			switch (this._is) {
 				case 'att':
 				case 'tag':
 					this.tag = null;
@@ -81,19 +77,19 @@ class Markup {
 	}
 
 	/**
-	 * Quote chars. We may assume the author to use double 
+	 * Quote chars. We may assume the author to use double
 	 * quotes, single quotes and no quotes for attributes.
 	 * @param {string} c
 	 */
 	_onquote(c) {
 		var previndex = this._index - 1;
-		switch(this._is) {
+		switch (this._is) {
 			case 'val':
-				if(this._quotes) {
-					if(this._quotes === c && this._prevchar !== '\\') {
+				if (this._quotes) {
+					if (this._quotes === c && this._prevchar !== '\\') {
 						this._go('att');
 					}
-				} else if(this._was(previndex, 'att')) {
+				} else if (this._was(previndex, 'att')) {
 					this._quotes = c;
 				}
 				break;
@@ -109,13 +105,13 @@ class Markup {
 	 * @param {string} c
 	 */
 	_onspace(c) {
-		switch(this._is) {
+		switch (this._is) {
 			case 'tag':
 				this.tag = this._buffer.trim();
 				this._go('att');
 				break;
 			case 'val':
-				if(!this._quotes) {
+				if (!this._quotes) {
 					this._go('att');
 				}
 				break;
@@ -130,7 +126,7 @@ class Markup {
 	 * @param {string} c
 	 */
 	_onequal(c) {
-		if(this._is === 'att') {
+		if (this._is === 'att') {
 			this._go('val');
 		} else {
 			this._buf(c);
@@ -150,12 +146,8 @@ class Markup {
 	 * @param {string} newis
 	 */
 	_go(newis) {
-		if(this._is !== null) {
-			this._snapshots.push([
-				this._index,
-				this._is,
-				this._buffer
-			]);
+		if (this._is !== null) {
+			this._snapshots.push([this._index, this._is, this._buffer]);
 		}
 		this._quotes = null;
 		this._buffer = '';
@@ -168,13 +160,18 @@ class Markup {
 	 * @param {string} type
 	 */
 	_was(index, type) {
-		var ix, it, match, snap, prev, snaps = this._snapshots;
-		if(snaps.length) {
+		var ix,
+			it,
+			match,
+			snap,
+			prev,
+			snaps = this._snapshots;
+		if (snaps.length) {
 			it = snaps.length - 1;
-			while(!match && (snap = snaps[it--])) {
-				if((ix = snap[0]) === index) {
+			while (!match && (snap = snaps[it--])) {
+				if ((ix = snap[0]) === index) {
 					match = snap;
-				} else if(ix < index) {
+				} else if (ix < index) {
 					match = prev;
 				}
 				prev = snap;
@@ -184,51 +181,59 @@ class Markup {
 		return false;
 	}
 
-
 	// Deboogie ..................................................................
 
 	/**
-	 * Quick and dirty debugging: The string 
+	 * Quick and dirty debugging: The string
 	 * in the console should look like HTML.
 	 * @param {Array<Array<string>>} snapshots
 	 */
 	_debug(snapshots) {
-		var index, is, was, buffer, yyy, next, end, tab = '\t', tabs = [];
-		console.log(snapshots.reduce(function(html, snap) {
-			index = snap[0];
-			is = snap[1];
-			buffer = snap[2];
-			switch(is) {
-				case 'tag':
-					if((end = buffer[0] === '/')) {
-						tabs.pop();
-					}
-					was = was === 'txt' && yyy.trim().length ? '' : was; 
-					next = (was ? '\n' + tabs.join('') : '') + '<' + buffer;
-					if(!end) {
-						tabs.push(tab);
-					}
-					break;
-				case 'att':
-					next = ' ' + buffer.trim();
-					if(next === ' ' ) {
-						next = '';
-					}
-					break;
-				case 'val':
-					next = '="' + buffer + '"';
-					break;
-				case 'txt':
-					next = (was ? '>' : '') + buffer;
-					break;
-			}
-			was = is;
-			yyy = buffer;
-			return html + next;
-		}, '') + (was === 'tag' ? '>' : ''));
+		var index,
+			is,
+			was,
+			buffer,
+			yyy,
+			next,
+			end,
+			tab = '\t',
+			tabs = [];
+		console.log(
+			snapshots.reduce(function(html, snap) {
+				index = snap[0];
+				is = snap[1];
+				buffer = snap[2];
+				switch (is) {
+					case 'tag':
+						if ((end = buffer[0] === '/')) {
+							tabs.pop();
+						}
+						was = was === 'txt' && yyy.trim().length ? '' : was;
+						next = (was ? '\n' + tabs.join('') : '') + '<' + buffer;
+						if (!end) {
+							tabs.push(tab);
+						}
+						break;
+					case 'att':
+						next = ' ' + buffer.trim();
+						if (next === ' ') {
+							next = '';
+						}
+						break;
+					case 'val':
+						next = '="' + buffer + '"';
+						break;
+					case 'txt':
+						next = (was ? '>' : '') + buffer;
+						break;
+				}
+				was = is;
+				yyy = buffer;
+				return html + next;
+			}, '') + (was === 'tag' ? '>' : '')
+		);
 	}
 }
-
 
 // Static ......................................................................
 

--- a/src/helpers/Output.js
+++ b/src/helpers/Output.js
@@ -1,14 +1,13 @@
-"use strict";
+'use strict';
 
 /**
  * Collecting JS code.
  */
 class Output {
-
 	/**
 	 * @param @optional {string} body
 	 */
-	constructor(body = "") {
+	constructor(body = '') {
 		this.body = body;
 		this.temp = null;
 	}

--- a/src/helpers/Result.js
+++ b/src/helpers/Result.js
@@ -1,10 +1,9 @@
-"use strict";
+'use strict';
 
 /**
  * Collapsing everything into a single function declaration.
  */
 class Result {
-
 	/**
 	 * @param {string} body
 	 * @param {Array<String>} params
@@ -26,16 +25,14 @@ class Result {
 		var js;
 		try {
 			js = "'use strict'\n;" + body;
-			js = new Function(params.join(","), body).toString();
-			js = js.replace(/^function anonymous/, "function $edbml");
-			js = js.replace(/\&quot;\&apos;/g, "&quot;");
+			js = new Function(params.join(','), body).toString();
+			js = js.replace(/^function anonymous/, 'function $edbml');
+			js = js.replace(/\&quot;\&apos;/g, '&quot;');
 			return js;
 		} catch (exception) {
 			this.instructionset = null;
 			this.errormessage = exception.message;
-			return this._tofallbackstring(
-				body, params, exception.message
-			);
+			return this._tofallbackstring(body, params, exception.message);
 		}
 	}
 
@@ -47,9 +44,9 @@ class Result {
 	 */
 	_tofallbackstring(body, params, exception) {
 		body = this._emergencyformat(body, params);
-		body = new Buffer(body).toString("base64");
+		body = new Buffer(body).toString('base64');
 		body = "gui.BlobLoader.loadScript ( document, atob (  '" + body + "' ));\n";
-		body += "return '<p class=\"edberror\">" + exception + "</p>'";
+		body += 'return \'<p class="edberror">' + exception + "</p>'";
 		return this._tofunctionstring(body);
 	}
 
@@ -59,30 +56,26 @@ class Result {
 	 * @returns {string}
 	 */
 	_emergencyformat(body, params) {
-		var result = "",
-			tabs = "\t",
+		var result = '',
+			tabs = '\t',
 			init = null,
 			last = null,
 			fixt = null,
 			hack = null;
-		body.split("\n").forEach((line) => {
+		body.split('\n').forEach(line => {
 			line = line.trim();
 			init = line[0];
 			last = line[line.length - 1];
-			fixt = line.split("//")[0].trim();
+			fixt = line.split('//')[0].trim();
 			hack = fixt[fixt.length - 1];
-			if ((init === "}" || init === "]") && tabs !== "") {
+			if ((init === '}' || init === ']') && tabs !== '') {
 				tabs = tabs.slice(0, -1);
 			}
-			result += tabs + line + "\n";
-			if (last === "{" || last === "[" || hack === "{" || hack === "[") {
-				tabs += "\t";
+			result += tabs + line + '\n';
+			if (last === '{' || last === '[' || hack === '{' || hack === '[') {
+				tabs += '\t';
 			}
 		});
-		return [
-			"function dysfunction (" + params + ") {",
-			result,
-			"}"
-		].join("\n");
+		return ['function dysfunction (' + params + ') {', result, '}'].join('\n');
 	}
 }

--- a/src/helpers/Runner.js
+++ b/src/helpers/Runner.js
@@ -1,11 +1,10 @@
-"use strict";
+'use strict';
 
 /**
  * Script runner. Iterating strings one character at a time
  * while using advanced algorithms to look ahead and behind.
  */
 class Runner {
-
 	/**
 	 * Let's go.
 	 */
@@ -27,7 +26,7 @@ class Runner {
 	 * @param {Output} output
 	 */
 	run(compiler, script, status, markup, output) {
-		this._runlines(compiler, script.split("\n"), status, markup, output);
+		this._runlines(compiler, script.split('\n'), status, markup, output);
 		// markup.debug(); // uncomment to debug Markup.js
 	}
 
@@ -73,9 +72,8 @@ class Runner {
 	 * @returns {boolean}
 	 */
 	skipahead(string) {
-		console.error("TODO");
+		console.error('TODO');
 	}
-
 
 	// Private ...................................................................
 
@@ -109,7 +107,7 @@ class Runner {
 		line = this._line = line.trim();
 		if (line.length) {
 			compiler.newline(line, this, status, markup, output);
-			this._runchars(compiler, line.split(""), status, markup, output);
+			this._runchars(compiler, line.split(''), status, markup, output);
 			compiler.endline(line, this, status, markup, output);
 		}
 	}

--- a/src/helpers/Status.js
+++ b/src/helpers/Status.js
@@ -1,10 +1,9 @@
-"use strict";
+'use strict';
 
 /**
  * Tracking compiler state while compiling.
  */
 class Status {
-
 	constructor() {
 		this.mode = Status.MODE_JS;
 		this.conf = [];
@@ -67,9 +66,8 @@ class Status {
 	}
 }
 
-
 // Static ...............................
 
-Status.MODE_JS = "js";
-Status.MODE_HTML = "html";
-Status.MODE_TAG = "tag";
+Status.MODE_JS = 'js';
+Status.MODE_HTML = 'html';
+Status.MODE_TAG = 'tag';

--- a/src/helpers/Stripper.js
+++ b/src/helpers/Stripper.js
@@ -1,10 +1,9 @@
-"use strict";
+'use strict';
 
 /**
  * Strip out comments in the crudest possible way.
  */
 class Stripper {
-
 	/**
 	 * Strip HTML and JS comments.
 	 * @param {string} script
@@ -17,7 +16,6 @@ class Stripper {
 		return script;
 	}
 
-
 	// Private ...................................................................
 
 	/**
@@ -29,7 +27,7 @@ class Stripper {
 	_stripout(script, s1, s2) {
 		var first = s1[0] === '^';
 		s1 = first ? s1.substring(1) : s1;
-		if(script.contains(s1) && script.contains(s2)) {
+		if (script.contains(s1) && script.contains(s2)) {
 			script = this._stripall(script, s1, s2, first);
 		}
 		return script;
@@ -66,8 +64,8 @@ class Stripper {
 			},
 			begins = (c, i) => {
 				var does = true;
-				while(i > 0 && (c = script[--i]) !== '\n') {
-					if(!c.match(WHITESPACE)) {
+				while (i > 0 && (c = script[--i]) !== '\n') {
+					if (!c.match(WHITESPACE)) {
 						does = false;
 						break;
 					}
@@ -82,25 +80,26 @@ class Stripper {
 				return c === c2 && prevs(i, s2);
 			};
 		chars = script.split('');
-		return chars.map((chaa, i) => {
-			if (pass) {
-				if (stops(chaa, i)) {
-					next = true;
+		return chars
+			.map((chaa, i) => {
+				if (pass) {
+					if (stops(chaa, i)) {
+						next = true;
+					}
+				} else {
+					if (start(chaa, i)) {
+						pass = true;
+					}
 				}
-			} else {
-				if (start(chaa, i)) {
-					pass = true;
+				if (pass || next) {
+					chaa = '';
 				}
-			}
-			if (pass || next) {
-				chaa = '';
-			}
-			if (next) {
-				pass = false;
-				next = false;
-			}
-			return chaa;
-		}).join('');
+				if (next) {
+					pass = false;
+					next = false;
+				}
+				return chaa;
+			})
+			.join('');
 	}
-
 }

--- a/tasks/edbml.js
+++ b/tasks/edbml.js
@@ -1,15 +1,15 @@
-"use strict";
+'use strict';
 
-var inliner = require("./things/inliner");
-var outliner = require("./things/outliner");
-var macrunner = require("./things/macrunner");
+var inliner = require('./things/inliner');
+var outliner = require('./things/outliner');
+var macrunner = require('./things/macrunner');
 
 /**
  * Here it comes.
  * @param {Grunt} grunt
  */
 module.exports = function(grunt) {
-	grunt.registerMultiTask("edbml", "Trawl EDBML", function() {
+	grunt.registerMultiTask('edbml', 'Trawl EDBML', function() {
 		var options = this.options();
 		var macros = macrunner.init(grunt, options);
 		var done = this.async();

--- a/tasks/things/assistant.js
+++ b/tasks/things/assistant.js
@@ -1,6 +1,6 @@
-"use strict";
+'use strict';
 
-var shorthash = require("./shorthash");
+var shorthash = require('./shorthash');
 
 /**
  * Genereate hash for file name.
@@ -8,7 +8,7 @@ var shorthash = require("./shorthash");
  * @returns {string}
  */
 exports.unique = function(filepath, index) {
-	return "$" + shorthash.unique(filepath) + index;
+	return '$' + shorthash.unique(filepath) + index;
 };
 
 /**
@@ -38,20 +38,20 @@ exports.declare = function(name, result) {
 	var json;
 	var fun = result.functionstring;
 	var pis = result.instructionset;
-	var output = "edbml.declare(\"" + name + "\").as(" + fun;
+	var output = 'edbml.declare("' + name + '").as(' + fun;
 	if (pis && (pis = filterpis(pis)).length) {
 		json = formatjson(pis);
 		json = JSON.stringify(json);
 		json = json.replace(/"(\w+)"\s*:/g, '$1:');
-		output += ").withInstructions(" + json + ");";
+		output += ').withInstructions(' + json + ');';
 	} else {
-		output += ");";
+		output += ');';
 	}
 	return output;
 };
 
 /**
- * Only relay <?input?> instructions to the client 
+ * Only relay <?input?> instructions to the client
  * since the rest aren't really needed right now.
  * @param {Array<Instruction>} pis
  * @returns {Array<Instruction>}
@@ -63,7 +63,7 @@ function filterpis(pis) {
 }
 
 /**
- * Format processing instructions 
+ * Format processing instructions
  * for slight improved readability.
  * @param {Array<Instruction>} pis
  * @returns {Array<object>}
@@ -87,12 +87,12 @@ function formatjson(pis) {
 function autocast(string) {
 	var result = String(string);
 	switch (result) {
-		case "null":
+		case 'null':
 			result = null;
 			break;
-		case "true":
-		case "false":
-			result = (result === "true");
+		case 'true':
+		case 'false':
+			result = result === 'true';
 			break;
 		default:
 			if (String(parseInt(result, 10)) === result) {
@@ -102,5 +102,5 @@ function autocast(string) {
 			}
 			break;
 	}
-	return result === "" ? true : result;
+	return result === '' ? true : result;
 }

--- a/tasks/things/compiler.js
+++ b/tasks/things/compiler.js
@@ -1,17 +1,5 @@
 "use strict";
 // Source: build/compiler-es5.js
-var _extends = function (child, parent) {
-  child.prototype = Object.create(parent.prototype, {
-    constructor: {
-      value: child,
-      enumerable: false,
-      writable: true,
-      configurable: true
-    }
-  });
-  child.__proto__ = parent;
-};
-
 /**
  * Call function for each own key in object (exluding the prototype stuff)
  * with key and value as arguments. Returns array of function call results.
@@ -19,12 +7,34 @@ var _extends = function (child, parent) {
  * @param {function} func
  * @param @optional {object} thisp
  */
+
+function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
+
+function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
 function each(object, func, thisp) {
   return Object.keys(object).map(function (key) {
     return func.call(thisp, key, object[key]);
   });
 }
-
 /**
  * Autocast string to an inferred type. "123" returns a number
  * while "true" and false" return a boolean. Empty string evals
@@ -32,300 +42,459 @@ function each(object, func, thisp) {
  * @param {string} string
  * @returns {object}
  */
+
+
 function cast(string) {
   var result = String(string);
+
   switch (result) {
-    case "null":
+    case 'null':
       result = null;
       break;
-    case "true":
-    case "false":
-      result = (result === "true");
+
+    case 'true':
+    case 'false':
+      result = result === 'true';
       break;
+
     default:
       if (String(parseInt(result, 10)) === result) {
         result = parseInt(result, 10);
       } else if (String(parseFloat(result)) === result) {
         result = parseFloat(result);
       }
+
       break;
   }
-  return result === "" ? true : result;
-}
 
+  return result === '' ? true : result;
+}
 /**
  * Generate unique key.
  * Note: Key structure must be kept in sync with {gui.KeyMaster#generatekey}.
  * @returns {string}
  */
-var generateKey = (function () {
+
+
+var generateKey = function () {
   var keys = {};
   return function () {
     var ran = Math.random().toString();
-    var key = "key" + ran.slice(2, 11);
+    var key = 'key' + ran.slice(2, 11);
+
     if (keys[key]) {
       key = generateKey();
     } else {
       keys[key] = true;
     }
+
     return key;
   };
-}());
-
+}();
 /**
  * What? This is wrong on so many.
  * @param {string} string
  * @returns {boolean}
  */
+
+
 String.prototype.contains = function (string) {
   return this.indexOf(string) > -1;
 };
-
 /**
  * Come on.
  * @param {string} string
  * @returns {boolean}
  */
+
+
 String.prototype.startsWith = function (string) {
   return this.indexOf(string) === 0;
 };
-
 /**
  * Again? That's it. Good luck.
  * @param {string} string
  * @returns {boolean}
  */
+
+
 String.prototype.endsWith = function (string) {
   return this.indexOf(string) === this.length - 1;
 };
-
-
 
 /**
  * Base compiler.
  * Note to self: Conceptualize peek|poke|geek|passout|lockout
  */
-var Compiler = (function () {
-  var Compiler =
 
+
+var Compiler =
+/*#__PURE__*/
+function () {
   /**
    * Let's go.
    */
   function Compiler() {
+    _classCallCheck(this, Compiler);
+
     this._keycounter = 0;
-  };
+  }
+  /**
+   * Line begins.
+   * @param {string} line
+   * @param {Runner} runner
+   * @param {Status} status
+   * @param {Markup} markup
+   * @param {Output} output
+   */
 
-  Compiler.prototype.newline = function (line, runner, status, markup, output) {
-    status.last = line.length - 1;
-    status.adds = line[0] === "+";
-    status.cont = status.cont || (status.ishtml() && status.adds);
-  };
 
-  Compiler.prototype.endline = function (line, runner, status, markup, output) {
-    if (status.ishtml()) {
-      if (!status.cont) {
-        output.body += "';\n";
-        status.gojs();
-      }
-    } else {
-      output.body += "\n";
+  _createClass(Compiler, [{
+    key: "newline",
+    value: function newline(line, runner, status, markup, output) {
+      status.last = line.length - 1;
+      status.adds = line[0] === '+';
+      status.cont = status.cont || status.ishtml() && status.adds;
     }
-    status.cont = false;
-  };
+    /**
+     * Line ends.
+     * @param {string} line
+     * @param {Runner} runner
+     * @param {Status} status
+     * @param {Markup} markup
+     * @param {Output} output
+     */
 
-  Compiler.prototype.nextchar = function (c, runner, status, markup, output) {
-    switch (status.mode) {
-      case Status.MODE_JS:
-        this._compilejs(c, runner, status, markup, output);
-        break;
-      case Status.MODE_HTML:
-        this._compilehtml(c, runner, status, markup, output);
-        break;
-    }
-    if (status.skip-- <= 0) {
-      if (status.poke || status.geek) {
-        output.temp += c;
+  }, {
+    key: "endline",
+    value: function endline(line, runner, status, markup, output) {
+      if (status.ishtml()) {
+        if (!status.cont) {
+          output.body += "';\n";
+          status.gojs();
+        }
       } else {
-        if (!status.istag()) {
-          output.body += c;
+        output.body += '\n';
+      }
+
+      status.cont = false;
+    }
+    /**
+     * Next char.
+     * @param {string} c
+     * @param {Runner} runner
+     * @param {Status} status
+     * @param {Markup} markup
+     * @param {Output} output
+     */
+
+  }, {
+    key: "nextchar",
+    value: function nextchar(c, runner, status, markup, output) {
+      switch (status.mode) {
+        case Status.MODE_JS:
+          this._compilejs(c, runner, status, markup, output);
+
+          break;
+
+        case Status.MODE_HTML:
+          this._compilehtml(c, runner, status, markup, output);
+
+          break;
+      }
+
+      if (status.skip-- <= 0) {
+        if (status.poke || status.geek) {
+          output.temp += c;
+        } else {
+          if (!status.istag()) {
+            output.body += c;
+          }
         }
       }
-    }
-    if (runner.done) {
-      markup.debug();
-    }
-  };
 
-  Compiler.prototype._compile = function (script) {
-    var runner = new Runner();
-    var status = new Status();
-    var markup = new Markup();
-    var output = new Output();
-    runner.run(this, script, status, markup, output);
-    output.body += (status.ishtml() ? "';" : "") + "\nreturn out.write ();";
-    return output.body;
-  };
+      if (runner.done) {
+        markup.debug();
+      }
+    } // Private ...................................................................
 
-  Compiler.prototype._compilejs = function (c, runner, status, markup, output) {
-    switch (c) {
-      case "<":
-        if (runner.firstchar) {
-          status.gohtml();
-          markup.next(c);
-          status.spot = output.body.length - 1;
-          output.body += "out.html += '";
-        }
-        break;
-      case "@":
-        // handled by the @ macro
-        break;
+    /**
+     * Compile EDBML source to function body.
+     * @param {string} script
+     * @returns {string}
+     */
+
+  }, {
+    key: "_compile",
+    value: function _compile(script) {
+      var runner = new Runner();
+      var status = new Status();
+      var markup = new Markup();
+      var output = new Output();
+      runner.run(this, script, status, markup, output);
+      output.body += (status.ishtml() ? "';" : '') + '\nreturn out.write ();';
+      return output.body;
     }
-  };
+    /**
+     * Compile character as script.
+     * @param {string} c
+     * @param {Runner} runner
+     * @param {Status} status
+     * @param {Markup} markup
+     * @param {Output} output
+     */
 
-  Compiler.prototype._compilehtml = function (c, runner, status, markup, output) {
-    var special = status.peek || status.poke || status.geek;
-    if (!this._continueshtml(c, runner, status)) {
-      var context = markup.next(c);
+  }, {
+    key: "_compilejs",
+    value: function _compilejs(c, runner, status, markup, output) {
       switch (c) {
-        case "{":
-          if (special) {
-            status.curl++;
+        case '<':
+          if (runner.firstchar) {
+            status.gohtml();
+            markup.next(c);
+            status.spot = output.body.length - 1;
+            output.body += "out.html += '";
           }
+
           break;
-        case "}":
-          if (--status.curl === 0) {
-            if (status.peek) {
-              status.peek = false;
-              status.skip = 1;
-              status.curl = 0;
-              output.body += ") + '";
-            }
-            if (status.poke) {
-              this._poke(status, markup, output);
-              status.poke = false;
-              output.temp = null;
-              status.skip = 1;
-              status.curl = 0;
-            }
-            if (status.geek) {
-              this._geek(status, markup, output);
-              status.geek = false;
-              output.temp = null;
-              status.skip = 1;
-              status.curl = 0;
-            }
-          }
-          break;
-        case "$":
-          if (!special && runner.ahead("{")) {
-            status.peek = true;
-            status.skip = 2;
-            status.curl = 0;
-            output.body += "' + " + this._escapefrom(context) + " (";
-          }
-          break;
-        case "#":
-          if (!special && runner.ahead("{")) {
-            status.poke = true;
-            status.skip = 2;
-            status.curl = 0;
-            output.temp = "";
-          }
-          break;
-        case "?":
-          if (!special && runner.ahead("{")) {
-            status.geek = true;
-            status.skip = 2;
-            status.curl = 0;
-            output.temp = "";
-          }
-          break;
-        case "'":
-          if (!special) {
-            output.body += "\\";
-          }
-          break;
-        case "@":
-          this._htmlatt(runner, status, markup, output);
+
+        case '@':
+          // handled by the @ macro
           break;
       }
     }
-  };
+    /**
+     * Compile character as HTML.
+     * @param {string} c
+     * @param {Runner} runner
+     * @param {Status} status
+     * @param {Markup} markup
+     * @param {Output} output
+     */
 
-  Compiler.prototype._continueshtml = function (c, runner, status) {
-    if (c === "+") {
-      if (runner.firstchar) {
-        status.skip = status.adds ? 1 : 0;
-        return true;
-      } else if (runner.lastchar) {
-        status.cont = true;
-        status.skip = 1;
-        return true;
+  }, {
+    key: "_compilehtml",
+    value: function _compilehtml(c, runner, status, markup, output) {
+      var special = status.peek || status.poke || status.geek;
+
+      if (!this._continueshtml(c, runner, status)) {
+        var context = markup.next(c);
+
+        switch (c) {
+          case '{':
+            if (special) {
+              status.curl++;
+            }
+
+            break;
+
+          case '}':
+            if (--status.curl === 0) {
+              if (status.peek) {
+                status.peek = false;
+                status.skip = 1;
+                status.curl = 0;
+                output.body += ") + '";
+              }
+
+              if (status.poke) {
+                this._poke(status, markup, output);
+
+                status.poke = false;
+                output.temp = null;
+                status.skip = 1;
+                status.curl = 0;
+              }
+
+              if (status.geek) {
+                this._geek(status, markup, output);
+
+                status.geek = false;
+                output.temp = null;
+                status.skip = 1;
+                status.curl = 0;
+              }
+            }
+
+            break;
+
+          case '$':
+            if (!special && runner.ahead('{')) {
+              status.peek = true;
+              status.skip = 2;
+              status.curl = 0;
+              output.body += "' + " + this._escapefrom(context) + ' (';
+            }
+
+            break;
+
+          case '#':
+            if (!special && runner.ahead('{')) {
+              status.poke = true;
+              status.skip = 2;
+              status.curl = 0;
+              output.temp = '';
+            }
+
+            break;
+
+          case '?':
+            if (!special && runner.ahead('{')) {
+              status.geek = true;
+              status.skip = 2;
+              status.curl = 0;
+              output.temp = '';
+            }
+
+            break;
+
+          case "'":
+            if (!special) {
+              output.body += '\\';
+            }
+
+            break;
+
+          case '@':
+            this._htmlatt(runner, status, markup, output);
+
+            break;
+        }
       }
     }
-    return false;
-  };
+    /**
+     * HTML continues on next line or
+     * was continued from previous line?
+     * @param {string} c
+     * @param {Runner} runner
+     * @param {Status} status
+     * @returns {boolean}
+     */
 
-  Compiler.prototype._escapefrom = function (context) {
-    switch (context) {
-      case Markup.CONTEXT_TXT:
-        return "$txt";
-      case Markup.CONTEXT_VAL:
-        return "$val";
-      default:
-        return "";
+  }, {
+    key: "_continueshtml",
+    value: function _continueshtml(c, runner, status) {
+      if (c === '+') {
+        if (runner.firstchar) {
+          status.skip = status.adds ? 1 : 0;
+          return true;
+        } else if (runner.lastchar) {
+          status.cont = true;
+          status.skip = 1;
+          return true;
+        }
+      }
+
+      return false;
     }
-  };
+    /**
+     * Get function to escape potentially
+     * unsafe text in given markup context.
+     * @param {string} context Markup state
+     * @returns {string} Function name
+     */
 
-  Compiler.prototype._htmlatt = function (runner, status, markup, output) {
-    var attr = Compiler._ATTREXP;
-    var rest, name, dels, what;
-    if (runner.behind("@")) {} else if (runner.behind("#{")) {
-      console.error("todo");
-    } else if (runner.ahead("@")) {
-      output.body += "' + $att.$all() + '";
-      status.skip = 2;
-    } else {
-      rest = runner.lineahead();
-      name = attr.exec(rest)[0];
-      dels = runner.behind("-");
-      what = dels ? "$att.$pop" : "$att.$";
-      output.body = dels ? output.body.substring(0, output.body.length - 1) : output.body;
-      output.body += "' + " + what + " ( '" + name + "' ) + '";
-      status.skip = name.length + 1;
+  }, {
+    key: "_escapefrom",
+    value: function _escapefrom(context) {
+      switch (context) {
+        case Markup.CONTEXT_TXT:
+          return '$txt';
+
+        case Markup.CONTEXT_VAL:
+          return '$val';
+
+        default:
+          return '';
+      }
     }
-  };
+    /**
+     * Parse @ notation in HTML.
+     * @param {Runner} runner
+     * @param {Status} status
+     * @param {Markup} markup
+     * @param {Output} output
+     */
 
-  Compiler.prototype._poke = function (status, markup, output) {
-    var tag = markup.tag || "";
-    var arg = tag.match(/input|textarea/) ? "value, checked" : "";
-    this._injectcombo(status, markup, output, {
-      outline: "var $name = $set(function(" + arg + ") {\n$temp;\n}, this);",
-      inline: "edbml.$run(this, \\'' + $name + '\\');"
-    });
-  };
+  }, {
+    key: "_htmlatt",
+    value: function _htmlatt(runner, status, markup, output) {
+      var attr = Compiler._ATTREXP;
+      var rest, name, dels, what;
 
-  Compiler.prototype._geek = function (status, markup, output) {
-    this._injectcombo(status, markup, output, {
-      outline: "var $name = $set(function() {\nreturn $temp;\n}, this);",
-      inline: "edbml.$get(&quot;' + $name + '&quot;);"
-    });
-  };
+      if (runner.behind('@')) {} else if (runner.behind('#{')) {
+        console.error('todo');
+      } else if (runner.ahead('@')) {
+        output.body += "' + $att.$all() + '";
+        status.skip = 2;
+      } else {
+        rest = runner.lineahead();
+        name = attr.exec(rest)[0];
+        dels = runner.behind('-');
+        what = dels ? '$att.$pop' : '$att.$';
+        output.body = dels ? output.body.substring(0, output.body.length - 1) : output.body;
+        output.body += "' + " + what + " ( '" + name + "' ) + '";
+        status.skip = name.length + 1;
+      }
+    }
+    /**
+     * Generate $poke at marked spot.
+     * @param {Status} status
+     * @param {Markup} markup
+     * @param {Output} output
+     */
 
-  Compiler.prototype._injectcombo = function (status, markup, output, combo) {
-    var body = output.body, temp = output.temp, spot = status.spot, prev = body.substring(0, spot), next = body.substring(spot), name = "$" + (++this._keycounter);
-    var outl = combo.outline.replace("$name", name).replace("$temp", temp);
-    output.body = prev + "\n" + outl + next + combo.inline.replace("$name", name);
-    status.spot += outl.length + 1;
-  };
+  }, {
+    key: "_poke",
+    value: function _poke(status, markup, output) {
+      var tag = markup.tag || '';
+      var arg = tag.match(/input|textarea/) ? 'value, checked' : '';
+
+      this._injectcombo(status, markup, output, {
+        outline: 'var $name = $set(function(' + arg + ') {\n$temp;\n}, this);',
+        inline: "edbml.$run(this, \\'' + $name + '\\');"
+      });
+    }
+    /**
+     * Generate ?geek at marked spot.
+     * @param {Status} status
+     * @param {Markup} markup
+     * @param {Output} output
+     */
+
+  }, {
+    key: "_geek",
+    value: function _geek(status, markup, output) {
+      this._injectcombo(status, markup, output, {
+        outline: 'var $name = $set(function() {\nreturn $temp;\n}, this);',
+        inline: "edbml.$get(&quot;' + $name + '&quot;);"
+      });
+    }
+    /**
+     * Inject outline and inline combo at marked spot.
+     * @param {Status} status
+     * @param {Markup} markup
+     * @param {Output} output
+     * @param {Map<string,string>} combo
+     */
+
+  }, {
+    key: "_injectcombo",
+    value: function _injectcombo(status, markup, output, combo) {
+      var body = output.body,
+          temp = output.temp,
+          spot = status.spot,
+          prev = body.substring(0, spot),
+          next = body.substring(spot),
+          name = '$' + ++this._keycounter;
+      var outl = combo.outline.replace('$name', name).replace('$temp', temp);
+      output.body = prev + '\n' + outl + next + combo.inline.replace('$name', name);
+      status.spot += outl.length + 1;
+    }
+  }]);
 
   return Compiler;
-})();
-
-
-
-
-// Static ......................................................................
+}(); // Static ......................................................................
 
 /**
  * Matches a qualified attribute name (class,id,src,href) allowing
@@ -334,173 +503,273 @@ var Compiler = (function () {
  * TODO: https://github.com/jshint/jshint/issues/383
  * @type {RegExp}
  */
+
+
 Compiler._ATTREXP = /^[^\d][a-zA-Z0-9-_\.]+/;
-
-
-
 /**
  * Function compiler.
  * @extends {Compiler}
  */
-var FunctionCompiler = (function (Compiler) {
-  var FunctionCompiler =
+
+
+var FunctionCompiler =
+/*#__PURE__*/
+function (_Compiler) {
+  _inherits(FunctionCompiler, _Compiler);
 
   /**
    * Construction time again.
    */
   function FunctionCompiler() {
-    Compiler.call(this);
+    var _this;
 
+    _classCallCheck(this, FunctionCompiler);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(FunctionCompiler).call(this));
     /**
      * Compile sequence.
      * @type {Array<function>}
      */
-    this._sequence = [this._uncomment, this._validate, this._extract, this._direct, this._compile, this._definehead, this._injecthead, this._macromize];
 
+    _this._sequence = [_this._uncomment, _this._validate, _this._extract, _this._direct, _this._compile, _this._definehead, _this._injecthead, _this._macromize];
     /**
      * Options from Grunt.
      * @type {Map}
      */
-    this._options = null;
 
+    _this._options = null;
     /**
      * Hm.
      */
-    this._macros = null;
 
+    _this._macros = null;
     /**
      * Mapping script tag attributes.
      * This may be put to future use.
      * @type {Map<string,string>}
      */
-    this._directives = null;
 
+    _this._directives = null;
     /**
      * Processing intstructions.
      * @type {Array<Instruction>}
      */
-    this._instructions = null;
 
+    _this._instructions = null;
     /**
      * Compiled arguments list.
      * @type {Array<string>}
      */
-    this._params = null;
 
+    _this._params = null;
     /**
      * Tracking imported functions.
      * @type {Map<string,string>}
      */
-    this._functions = {};
 
+    _this._functions = {};
     /**
      * Did compilation fail just yet?
      * @type {boolean}
      */
-    this._failed = false;
-  };
 
-  _extends(FunctionCompiler, Compiler);
+    _this._failed = false;
+    return _this;
+  }
+  /**
+   * Compile EDBML source to function.
+   * @param {string} source
+   * @param {Map<string,string} options
+   * @param {???} macros
+   * @param {Map<string,string} directives
+   * @returns {Result}
+   */
 
-  FunctionCompiler.prototype.compile = function (source, options, macros, directives) {
-    var _this = this;
-    this._directives = directives || {};
-    this._options = options || {};
-    this._macros = macros;
-    this._params = [];
-    this._functions = {};
-    this._head = {};
-    source = this._sequence.reduce(function (s, step) {
-      return step.call(_this, s);
-    }, source);
-    return new Result(source, this._params, this._instructions);
-  };
 
-  FunctionCompiler.prototype._uncomment = function (script) {
-    return new Stripper().strip(script);
-  };
+  _createClass(FunctionCompiler, [{
+    key: "compile",
+    value: function compile(source, options, macros, directives) {
+      var _this2 = this;
 
-  FunctionCompiler.prototype._validate = function (script) {
-    if (FunctionCompiler._NESTEXP.test(script)) {
-      throw "Nested EDBML dysfunction";
+      this._directives = directives || {};
+      this._options = options || {};
+      this._macros = macros;
+      this._params = [];
+      this._functions = {};
+      this._head = {};
+      source = this._sequence.reduce(function (s, step) {
+        return step.call(_this2, s);
+      }, source);
+      return new Result(source, this._params, this._instructions);
+    } // Private ...................................................................
+
+    /**
+     * Strip HTML and JS comments.
+     * @param {string} script
+     * @returns {string}
+     */
+
+  }, {
+    key: "_uncomment",
+    value: function _uncomment(script) {
+      return new Stripper().strip(script);
     }
-    return script;
-  };
+    /**
+     * Confirm no nested EDBML scripts.
+     * @see http://stackoverflow.com/a/6322601
+     * @param {string} script
+     * @returns {string}
+     */
 
-  FunctionCompiler.prototype._direct = function (script) {
-    return script;
-  };
+  }, {
+    key: "_validate",
+    value: function _validate(script) {
+      if (FunctionCompiler._NESTEXP.test(script)) {
+        throw 'Nested EDBML dysfunction';
+      }
 
-  FunctionCompiler.prototype._extract = function (script) {
-    var _this2 = this;
-    Instruction.from(script).forEach(function (pi) {
-      _this2._instructions = _this2._instructions || [];
-      _this2._instructions.push(pi);
-      _this2._instruct(pi);
-    });
-    return Instruction.clean(script);
-  };
-
-  FunctionCompiler.prototype._instruct = function (pi) {
-    var att = pi.att;
-    switch (pi.tag) {
-      case "param":
-        this._params.push(att.name);
-        break;
-      case "function":
-        this._functions[att.name] = att.src;
-        break;
+      return script;
     }
-  };
+    /**
+     * Handle directives. Nothing by default.
+     * @param  {string} script
+     * @returns {string}
+     */
 
-  FunctionCompiler.prototype._definehead = function (script) {
-    var head = this._head;
-    var params = this._params;
-    var functions = this._functions;
-    if (params.indexOf("out") < 0) {
-      head.out = "$edbml.$out__MACROFIX";
+  }, {
+    key: "_direct",
+    value: function _direct(script) {
+      return script;
     }
-    if (script.contains("@")) {
-      // TODO: run macros FIRST at look for '$att' ???
-      head.$att__MACROFIX = "$edbml.$att__MACROFIX";
-    }
-    if (script.contains("$set")) {
-      head.$set = "edbml.$set";
-    }
-    if (script.contains("$txt")) {
-      head.$txt = "edbml.safetext";
-    }
-    if (script.contains("$val")) {
-      head.$val = "edbml.safeattr";
-    }
-    each(functions, function (name, src) {
-      head[name] = src + ".lock(out)";
-    });
-    return script;
-  };
+    /**
+     * Extract and evaluate processing instructions.
+     * @param {string} script
+     * @returns {string}
+     */
 
-  FunctionCompiler.prototype._injecthead = function (script, head) {
-    return "'use strict';\n" + "var " + each(this._head, function (name, value) {
-      return name + (value !== undefined ? " = " + value : "");
-    }).join(",") + ";" + script;
-  };
+  }, {
+    key: "_extract",
+    value: function _extract(script) {
+      var _this3 = this;
 
-  FunctionCompiler.prototype._macromize = function (script) {
-    script = this._macros ? this._macros.compile(script) : script;
-    return script.replace(/__MACROFIX/g, "");
-  };
+      Instruction.from(script).forEach(function (pi) {
+        _this3._instructions = _this3._instructions || [];
 
-  FunctionCompiler.prototype._source = function (source, params) {
-    var lines = source.split("\n");
-    lines.pop(); // empty line :/
-    var args = params.length ? "( " + params.join(", ") + " )" : "()";
-    return "function " + args + " {\n" + lines.join("\n") + "\n}";
-  };
+        _this3._instructions.push(pi);
+
+        _this3._instruct(pi);
+      });
+      return Instruction.clean(script);
+    }
+    /**
+     * Evaluate processing instruction.
+     * @param {Instruction} pi
+     */
+
+  }, {
+    key: "_instruct",
+    value: function _instruct(pi) {
+      var att = pi.att;
+
+      switch (pi.tag) {
+        case 'param':
+          this._params.push(att.name);
+
+          break;
+
+        case 'function':
+          this._functions[att.name] = att.src;
+          break;
+      }
+    }
+    /**
+     * Define stuff in head. Using var name underscore hack
+     * to bypass the macro hygiene, will be normalized later.
+     * TODO: In string checks, also check for starting '('
+     * @param {string} script
+     * @param {object} head
+     * @returns {string}
+     */
+
+  }, {
+    key: "_definehead",
+    value: function _definehead(script) {
+      var head = this._head;
+      var params = this._params;
+      var functions = this._functions;
+
+      if (params.indexOf('out') < 0) {
+        head.out = '$edbml.$out__MACROFIX';
+      }
+
+      if (script.contains('@')) {
+        // TODO: run macros FIRST at look for '$att' ???
+        head.$att__MACROFIX = '$edbml.$att__MACROFIX';
+      }
+
+      if (script.contains('$set')) {
+        head.$set = 'edbml.$set';
+      }
+
+      if (script.contains('$txt')) {
+        head.$txt = 'edbml.safetext';
+      }
+
+      if (script.contains('$val')) {
+        head.$val = 'edbml.safeattr';
+      }
+
+      each(functions, function (name, src) {
+        head[name] = src + '.lock(out)';
+      });
+      return script;
+    }
+    /**
+     * Inject stuff in head. Let's just hope that V8 keeps on iterating
+     * object keys in chronological order (in which they were defined).
+     * @param {string} script
+     * @param {object} head
+     * @returns {string}
+     */
+
+  }, {
+    key: "_injecthead",
+    value: function _injecthead(script, head) {
+      return "'use strict';\n" + 'var ' + each(this._head, function (name, value) {
+        return name + (value !== undefined ? ' = ' + value : '');
+      }).join(',') + ';' + script;
+    }
+    /**
+     * Release the macros. Normalize variable names that were
+     * hacked  to bypass the internal macro hygiene routine.
+     * @param {string} script
+     * @returns {string}
+     */
+
+  }, {
+    key: "_macromize",
+    value: function _macromize(script) {
+      script = this._macros ? this._macros.compile(script) : script;
+      return script.replace(/__MACROFIX/g, '');
+    }
+    /**
+     * Compute full script source (including arguments) for debugging stuff.
+     * @returns {string}
+     */
+
+  }, {
+    key: "_source",
+    value: function _source(source, params) {
+      var lines = source.split('\n');
+      lines.pop(); // empty line :/
+
+      var args = params.length ? '( ' + params.join(', ') + ' )' : '()';
+      return 'function ' + args + ' {\n' + lines.join('\n') + '\n}';
+    }
+  }]);
 
   return FunctionCompiler;
-})(Compiler);
-
-// Static ......................................................................
+}(Compiler); // Static ......................................................................
 
 /**
  * RegExp used to validate no nested scripts. Important back when all this was a
@@ -511,16 +780,19 @@ var FunctionCompiler = (function (Compiler) {
  * TODO: stress test for no SRC attribute!
  * @type {RegExp}
  */
+
+
 FunctionCompiler._NESTEXP = /<script.*type=["']?text\/edbml["']?.*>([\s\S]+?)/g;
-
-
-
 /**
  * Script compiler.
  * @extends {FunctionCompiler}
  */
-var ScriptCompiler = (function (FunctionCompiler) {
-  var ScriptCompiler =
+
+
+var ScriptCompiler =
+/*#__PURE__*/
+function (_FunctionCompiler) {
+  _inherits(ScriptCompiler, _FunctionCompiler);
 
   /**
    * Map observed types.
@@ -528,334 +800,528 @@ var ScriptCompiler = (function (FunctionCompiler) {
    * @param {string} key
    */
   function ScriptCompiler() {
-    FunctionCompiler.call(this);
-    this.inputs = {};
-  };
+    var _this4;
 
-  _extends(ScriptCompiler, FunctionCompiler);
+    _classCallCheck(this, ScriptCompiler);
 
-  ScriptCompiler.prototype._instruct = function (pi) {
-    FunctionCompiler.prototype._instruct.call(this, pi);
-    var atts = pi.att;
-    switch (pi.tag) {
-      case "input":
-        this.inputs[atts.name] = atts.type;
-        break;
+    _this4 = _possibleConstructorReturn(this, _getPrototypeOf(ScriptCompiler).call(this));
+    _this4.inputs = {};
+    return _this4;
+  } // Private ...................................................................
+
+  /**
+   * Handle instruction.
+   * @overrides {FunctionCompiler._instruct}
+   * @param {Instruction} pi
+   */
+
+
+  _createClass(ScriptCompiler, [{
+    key: "_instruct",
+    value: function _instruct(pi) {
+      _get(_getPrototypeOf(ScriptCompiler.prototype), "_instruct", this).call(this, pi);
+
+      var atts = pi.att;
+
+      switch (pi.tag) {
+        case 'input':
+          this.inputs[atts.name] = atts.type;
+          break;
+      }
     }
-  };
+    /**
+     * Define stuff in head.
+     * @param {string} script
+     * @param {object} head
+     * @returns {string}
+     */
 
-  ScriptCompiler.prototype._definehead = function (script) {
-    var _this3 = this;
-    script = FunctionCompiler.prototype._definehead.call(this, script);
-    each(this.inputs, function (name, type) {
-      _this3._head[name] = "$edbml.$input(" + type + ")";
-    }, this);
-    return script;
-  };
+  }, {
+    key: "_definehead",
+    value: function _definehead(script) {
+      var _this5 = this;
+
+      script = _get(_getPrototypeOf(ScriptCompiler.prototype), "_definehead", this).call(this, script);
+      each(this.inputs, function (name, type) {
+        _this5._head[name] = '$edbml.$input(' + type + ')';
+      }, this);
+      return script;
+    }
+  }]);
 
   return ScriptCompiler;
-})(FunctionCompiler);
-
-
-
-
+}(FunctionCompiler);
 
 /**
  * EDB processing instruction.
  * TODO: Problem with one-letter variable names in <?input name="a" type="TestData"?>
  * @param {string} pi
  */
-var Instruction =
 
+
+var Instruction =
 /**
  * @param {string} pi
  */
 function Instruction(pi) {
-  this.tag = pi.split("<?")[1].split(" ")[0];
+  _classCallCheck(this, Instruction);
+
+  this.tag = pi.split('<?')[1].split(' ')[0];
   this.att = Object.create(null);
-  var hit, atexp = Instruction._ATEXP;
-  while ((hit = atexp.exec(pi))) {
-    var n = hit[1], v = hit[2];
+  var hit,
+      atexp = Instruction._ATEXP;
+
+  while (hit = atexp.exec(pi)) {
+    var n = hit[1],
+        v = hit[2];
     this.att[n] = cast(v);
   }
-};
-
-
-
-
-// Static ......................................................................
+}; // Static ......................................................................
 
 /**
  * Extract processing instructions from source.
  * @param {string} source
  * @returns {Array<Instruction>}
  */
+
+
 Instruction.from = function (source) {
-  var pis = [], hit = null;
-  while ((hit = this._PIEXP.exec(source))) {
+  var pis = [],
+      hit = null;
+
+  while (hit = this._PIEXP.exec(source)) {
     pis.push(new Instruction(hit[0]));
   }
+
   return pis;
 };
-
 /**
  * Remove processing instructions from source.
  * @param {string} source
  * @returns {string}
  */
-Instruction.clean = function (source) {
-  return source.replace(this._PIEXP, "");
-};
 
+
+Instruction.clean = function (source) {
+  return source.replace(this._PIEXP, '');
+};
 /**
  * Math processing instruction.
  * @type {RegExp}
  */
-Instruction._PIEXP = /<\?.[^>?]+\?>/g;
 
+
+Instruction._PIEXP = /<\?.[^>?]+\?>/g;
 /**
  * Match attribute name and value.
  * @type {RegExp}
  */
+
 Instruction._ATEXP = /(\S+)=["']?((?:.(?!["']?\s+(?:\S+)=|[>"']))+.)["']?/g;
-
-
-
 /**
  * Strip out comments in the crudest possible way.
  */
-var Stripper = (function () {
-  var Stripper = function Stripper() {};
 
-  Stripper.prototype.strip = function (script) {
-    script = this._stripout(script, "<!--", "-->");
-    script = this._stripout(script, "/*", "*/");
-    script = this._stripout(script, "^//", "\n");
-    return script;
-  };
 
-  Stripper.prototype._stripout = function (script, s1, s2) {
-    var first = s1[0] === "^";
-    s1 = first ? s1.substring(1) : s1;
-    if (script.contains(s1) && script.contains(s2)) {
-      script = this._stripall(script, s1, s2, first);
+var Stripper =
+/*#__PURE__*/
+function () {
+  function Stripper() {
+    _classCallCheck(this, Stripper);
+  }
+
+  _createClass(Stripper, [{
+    key: "strip",
+
+    /**
+     * Strip HTML and JS comments.
+     * @param {string} script
+     * @returns {string}
+     */
+    value: function strip(script) {
+      script = this._stripout(script, '<!--', '-->');
+      script = this._stripout(script, '/*', '*/');
+      script = this._stripout(script, '^//', '\n');
+      return script;
+    } // Private ...................................................................
+
+    /**
+     * Screening the stripper.
+     * @param {string} s1
+     * @param {string} s2
+     * @returns {string}
+     */
+
+  }, {
+    key: "_stripout",
+    value: function _stripout(script, s1, s2) {
+      var first = s1[0] === '^';
+      s1 = first ? s1.substring(1) : s1;
+
+      if (script.contains(s1) && script.contains(s2)) {
+        script = this._stripall(script, s1, s2, first);
+      }
+
+      return script;
     }
-    return script;
-  };
+    /**
+     * Strip all comments with no concern about the context they appear in...
+     * @param {string} s1
+     * @param {string} s2
+     * @param {boolean} first
+     * @returns {string}
+     */
 
-  Stripper.prototype._stripall = function (script, s1, s2, first) {
-    var WHITESPACE = /\s/;
-    var a1 = s1.split(""), a2 = s2.split(""), c1 = a1.shift(), c2 = a2.pop();
-    s1 = a1.join("");
-    s2 = a2.join("");
-    var chars = null, pass = false, next = false, fits = function (i, l, s) {
-      return chars.slice(i, l).join("") === s;
-    }, ahead = function (i, s) {
-      var l = s.length;
-      return fits(i, i + l, s);
-    }, prevs = function (i, s) {
-      var l = s.length;
-      return fits(i - l, i, s);
-    }, begins = function (c, i) {
-      var does = true;
-      while (i > 0 && (c = script[--i]) !== "\n") {
-        if (!c.match(WHITESPACE)) {
-          does = false;
-          break;
+  }, {
+    key: "_stripall",
+    value: function _stripall(script, s1, s2, first) {
+      var WHITESPACE = /\s/;
+      var a1 = s1.split(''),
+          a2 = s2.split(''),
+          c1 = a1.shift(),
+          c2 = a2.pop();
+      s1 = a1.join('');
+      s2 = a2.join('');
+
+      var chars = null,
+          pass = false,
+          next = false,
+          fits = function fits(i, l, s) {
+        return chars.slice(i, l).join('') === s;
+      },
+          ahead = function ahead(i, s) {
+        var l = s.length;
+        return fits(i, i + l, s);
+      },
+          prevs = function prevs(i, s) {
+        var l = s.length;
+        return fits(i - l, i, s);
+      },
+          begins = function begins(c, i) {
+        var does = true;
+
+        while (i > 0 && (c = script[--i]) !== '\n') {
+          if (!c.match(WHITESPACE)) {
+            does = false;
+            break;
+          }
         }
-      }
-      return does;
-    }, start = function (c, i) {
-      var does = c === c1 && ahead(i + 1, s1);
-      return does && first ? begins(c, i) : does;
-    }, stops = function (c, i) {
-      return c === c2 && prevs(i, s2);
-    };
-    chars = script.split("");
-    return chars.map(function (chaa, i) {
-      if (pass) {
-        if (stops(chaa, i)) {
-          next = true;
+
+        return does;
+      },
+          start = function start(c, i) {
+        var does = c === c1 && ahead(i + 1, s1);
+        return does && first ? begins(c, i) : does;
+      },
+          stops = function stops(c, i) {
+        return c === c2 && prevs(i, s2);
+      };
+
+      chars = script.split('');
+      return chars.map(function (chaa, i) {
+        if (pass) {
+          if (stops(chaa, i)) {
+            next = true;
+          }
+        } else {
+          if (start(chaa, i)) {
+            pass = true;
+          }
         }
-      } else {
-        if (start(chaa, i)) {
-          pass = true;
+
+        if (pass || next) {
+          chaa = '';
         }
-      }
-      if (pass || next) {
-        chaa = "";
-      }
-      if (next) {
-        pass = false;
-        next = false;
-      }
-      return chaa;
-    }).join("");
-  };
+
+        if (next) {
+          pass = false;
+          next = false;
+        }
+
+        return chaa;
+      }).join('');
+    }
+  }]);
 
   return Stripper;
-})();
-
-
-
-
+}();
 
 /**
  * Script runner. Iterating strings one character at a time
  * while using advanced algorithms to look ahead and behind.
  */
-var Runner = (function () {
-  var Runner =
 
+
+var Runner =
+/*#__PURE__*/
+function () {
   /**
    * Let's go.
    */
   function Runner() {
+    _classCallCheck(this, Runner);
+
     this.firstline = false;
     this.lastline = false;
     this.firstchar = false;
     this.lastchar = false;
     this._line = null;
     this._index = -1;
-  };
+  }
+  /**
+   * Run script.
+   * @param {Compiler} compiler
+   * @param {string} script
+   * @param {Status} status
+   * @param {Markup} markup
+   * @param {Output} output
+   */
 
-  Runner.prototype.run = function (compiler, script, status, markup, output) {
-    this._runlines(compiler, script.split("\n"), status, markup, output);
-    // markup.debug(); // uncomment to debug Markup.js
-  };
 
-  Runner.prototype.ahead = function (string) {
-    var line = this._line;
-    var index = this._index;
-    var i = index + 1;
-    var l = string.length;
-    return line.length > index + l && line.substring(i, i + l) === string;
-  };
+  _createClass(Runner, [{
+    key: "run",
+    value: function run(compiler, script, status, markup, output) {
+      this._runlines(compiler, script.split('\n'), status, markup, output); // markup.debug(); // uncomment to debug Markup.js
 
-  Runner.prototype.behind = function (string) {
-    var line = this._line;
-    var index = this._index;
-    var length = string.length, start = index - length;
-    return start >= 0 && line.substr(start, length) === string;
-  };
-
-  Runner.prototype.lineahead = function () {
-    return this._line.substring(this._index + 1);
-  };
-
-  Runner.prototype.skipahead = function (string) {
-    console.error("TODO");
-  };
-
-  Runner.prototype._runlines = function (compiler, lines, status, markup, output) {
-    var _this4 = this;
-    var stop = lines.length - 1;
-    lines.forEach(function (line, index) {
-      _this4.firstline = index === 0;
-      _this4.lastline = index === stop;
-      _this4._runline(line, index, compiler, status, markup, output);
-    });
-  };
-
-  Runner.prototype._runline = function (line, index, compiler, status, markup, output) {
-    line = this._line = line.trim();
-    if (line.length) {
-      compiler.newline(line, this, status, markup, output);
-      this._runchars(compiler, line.split(""), status, markup, output);
-      compiler.endline(line, this, status, markup, output);
     }
-  };
+    /**
+     * Line text ahead equals given string?
+     * @param {string} string
+     * @returns {boolean}
+     */
 
-  Runner.prototype._runchars = function (compiler, chars, status, markup, output) {
-    var _this5 = this;
-    var stop = chars.length - 1;
-    chars.forEach(function (c, i) {
-      _this5._index = i;
-      _this5.firstchar = i === 0;
-      _this5.lastchar = i === stop;
-      compiler.nextchar(c, _this5, status, markup, output);
-    });
-  };
+  }, {
+    key: "ahead",
+    value: function ahead(string) {
+      var line = this._line;
+      var index = this._index;
+      var i = index + 1;
+      var l = string.length;
+      return line.length > index + l && line.substring(i, i + l) === string;
+    }
+    /**
+     * Line text behind equals given string?
+     * @param {string} line
+     * @param {number} index
+     * @param {string} string
+     * @returns {boolean}
+     */
+
+  }, {
+    key: "behind",
+    value: function behind(string) {
+      var line = this._line;
+      var index = this._index;
+      var length = string.length,
+          start = index - length;
+      return start >= 0 && line.substr(start, length) === string;
+    }
+    /**
+     * Get line string from current position.
+     * @returns {string}
+     */
+
+  }, {
+    key: "lineahead",
+    value: function lineahead() {
+      return this._line.substring(this._index + 1);
+    }
+    /**
+     * Space-stripped line text at index equals string?
+     * @param {string} string
+     * @returns {boolean}
+     */
+
+  }, {
+    key: "skipahead",
+    value: function skipahead(string) {
+      console.error('TODO');
+    } // Private ...................................................................
+
+    /**
+     * Run all lines.
+     * @param {Compiler} compiler
+     * @param {Array<String>} lines
+     * @param {Status} status
+     * @param {Markup} markup
+     * @param {Output} output
+     */
+
+  }, {
+    key: "_runlines",
+    value: function _runlines(compiler, lines, status, markup, output) {
+      var _this6 = this;
+
+      var stop = lines.length - 1;
+      lines.forEach(function (line, index) {
+        _this6.firstline = index === 0;
+        _this6.lastline = index === stop;
+
+        _this6._runline(line, index, compiler, status, markup, output);
+      });
+    }
+    /**
+     * Run single line.
+     * @param {string} line
+     * @param {number} index
+     * @param {Compiler} compiler
+     * @param {Status} status
+     * @param {Markup} markup
+     * @param {Output} output
+     */
+
+  }, {
+    key: "_runline",
+    value: function _runline(line, index, compiler, status, markup, output) {
+      line = this._line = line.trim();
+
+      if (line.length) {
+        compiler.newline(line, this, status, markup, output);
+
+        this._runchars(compiler, line.split(''), status, markup, output);
+
+        compiler.endline(line, this, status, markup, output);
+      }
+    }
+    /**
+     * Run all chars.
+     * @param {Compiler} compiler
+     * @param {Array<String>} chars
+     * @param {Status} status
+     * @param {Markup} markup
+     * @param {Output} output
+     */
+
+  }, {
+    key: "_runchars",
+    value: function _runchars(compiler, chars, status, markup, output) {
+      var _this7 = this;
+
+      var stop = chars.length - 1;
+      chars.forEach(function (c, i) {
+        _this7._index = i;
+        _this7.firstchar = i === 0;
+        _this7.lastchar = i === stop;
+        compiler.nextchar(c, _this7, status, markup, output);
+      });
+    }
+  }]);
 
   return Runner;
-})();
-
-
-
-
+}();
 
 /**
  * Collapsing everything into a single function declaration.
  */
-var Result = (function () {
-  var Result =
 
+
+var Result =
+/*#__PURE__*/
+function () {
   /**
    * @param {string} body
    * @param {Array<String>} params
    * @param {Array<Instruction>} instructions
    */
   function Result(body, params, instructions) {
+    _classCallCheck(this, Result);
+
     this.functionstring = this._tofunctionstring(body, params);
     this.instructionset = instructions;
     this.errormessage = null;
-  };
+  }
+  /**
+   * Compute single function declaration.
+   * @param {string} script
+   * @param @optional (Array<String>} params
+   * @returns {string}
+   */
 
-  Result.prototype._tofunctionstring = function (body, params) {
-    if (params === undefined) params = [];
-    var js;
-    try {
-      js = "'use strict'\n;" + body;
-      js = new Function(params.join(","), body).toString();
-      js = js.replace(/^function anonymous/, "function $edbml");
-      js = js.replace(/\&quot;\&apos;/g, "&quot;");
-      return js;
-    } catch (exception) {
-      this.instructionset = null;
-      this.errormessage = exception.message;
-      return this._tofallbackstring(body, params, exception.message);
+
+  _createClass(Result, [{
+    key: "_tofunctionstring",
+    value: function _tofunctionstring(body) {
+      var params = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : [];
+      var js;
+
+      try {
+        js = "'use strict'\n;" + body;
+        js = new Function(params.join(','), body).toString();
+        js = js.replace(/^function anonymous/, 'function $edbml');
+        js = js.replace(/\&quot;\&apos;/g, '&quot;');
+        return js;
+      } catch (exception) {
+        this.instructionset = null;
+        this.errormessage = exception.message;
+        return this._tofallbackstring(body, params, exception.message);
+      }
     }
-  };
+    /**
+     * Fallback for invalid source.
+     * @param {string} script
+     * @param (Array<String>} params
+     * @returns {string}
+     */
 
-  Result.prototype._tofallbackstring = function (body, params, exception) {
-    body = this._emergencyformat(body, params);
-    body = new Buffer(body).toString("base64");
-    body = "gui.BlobLoader.loadScript ( document, atob (  '" + body + "' ));\n";
-    body += "return '<p class=\"edberror\">" + exception + "</p>'";
-    return this._tofunctionstring(body);
-  };
+  }, {
+    key: "_tofallbackstring",
+    value: function _tofallbackstring(body, params, exception) {
+      body = this._emergencyformat(body, params);
+      body = new Buffer(body).toString('base64');
+      body = "gui.BlobLoader.loadScript ( document, atob (  '" + body + "' ));\n";
+      body += 'return \'<p class="edberror">' + exception + "</p>'";
+      return this._tofunctionstring(body);
+    }
+    /**
+     * Format invalid source for readability.
+     * @param {string} body
+     * @returns {string}
+     */
 
-  Result.prototype._emergencyformat = function (body, params) {
-    var result = "", tabs = "\t", init = null, last = null, fixt = null, hack = null;
-    body.split("\n").forEach(function (line) {
-      line = line.trim();
-      init = line[0];
-      last = line[line.length - 1];
-      fixt = line.split("//")[0].trim();
-      hack = fixt[fixt.length - 1];
-      if ((init === "}" || init === "]") && tabs !== "") {
-        tabs = tabs.slice(0, -1);
-      }
-      result += tabs + line + "\n";
-      if (last === "{" || last === "[" || hack === "{" || hack === "[") {
-        tabs += "\t";
-      }
-    });
-    return ["function dysfunction (" + params + ") {", result, "}"].join("\n");
-  };
+  }, {
+    key: "_emergencyformat",
+    value: function _emergencyformat(body, params) {
+      var result = '',
+          tabs = '\t',
+          init = null,
+          last = null,
+          fixt = null,
+          hack = null;
+      body.split('\n').forEach(function (line) {
+        line = line.trim();
+        init = line[0];
+        last = line[line.length - 1];
+        fixt = line.split('//')[0].trim();
+        hack = fixt[fixt.length - 1];
+
+        if ((init === '}' || init === ']') && tabs !== '') {
+          tabs = tabs.slice(0, -1);
+        }
+
+        result += tabs + line + '\n';
+
+        if (last === '{' || last === '[' || hack === '{' || hack === '[') {
+          tabs += '\t';
+        }
+      });
+      return ['function dysfunction (' + params + ') {', result, '}'].join('\n');
+    }
+  }]);
 
   return Result;
-})();
-
-
-
-
+}();
 
 /**
  * Tracking compiler state while compiling.
  */
-var Status = (function () {
-  var Status = function Status() {
+
+
+var Status =
+/*#__PURE__*/
+function () {
+  function Status() {
+    _classCallCheck(this, Status);
+
     this.mode = Status.MODE_JS;
     this.conf = [];
     this.peek = false;
@@ -869,53 +1335,88 @@ var Status = (function () {
     this.last = 0;
     this.spot = 0;
     this.indx = 0;
-  };
+  }
+  /**
+   * Go JS mode.
+   */
 
-  Status.prototype.gojs = function () {
-    this.mode = Status.MODE_JS;
-  };
 
-  Status.prototype.gohtml = function () {
-    this.mode = Status.MODE_HTML;
-  };
+  _createClass(Status, [{
+    key: "gojs",
+    value: function gojs() {
+      this.mode = Status.MODE_JS;
+    }
+    /**
+     * Go HTML mode.
+     */
 
-  Status.prototype.gotag = function () {
-    this.mode = Status.MODE_TAG;
-  };
+  }, {
+    key: "gohtml",
+    value: function gohtml() {
+      this.mode = Status.MODE_HTML;
+    }
+    /**
+     * Go tag mode.
+     */
 
-  Status.prototype.isjs = function () {
-    return this.mode === Status.MODE_JS;
-  };
+  }, {
+    key: "gotag",
+    value: function gotag() {
+      this.mode = Status.MODE_TAG;
+    }
+    /**
+     * Is JS mode?
+     * @returns {boolean}
+     */
 
-  Status.prototype.ishtml = function () {
-    return this.mode === Status.MODE_HTML;
-  };
+  }, {
+    key: "isjs",
+    value: function isjs() {
+      return this.mode === Status.MODE_JS;
+    }
+    /**
+     * Is HTML mode?
+     * @returns {boolean}
+     */
 
-  Status.prototype.istag = function () {
-    return this.mode === Status.MODE_TAG;
-  };
+  }, {
+    key: "ishtml",
+    value: function ishtml() {
+      return this.mode === Status.MODE_HTML;
+    }
+    /**
+     * Is tag mode?
+     * @returns {boolean}
+     */
+
+  }, {
+    key: "istag",
+    value: function istag() {
+      return this.mode === Status.MODE_TAG;
+    }
+  }]);
 
   return Status;
-})();
+}(); // Static ...............................
 
 
-
-
-// Static ...............................
-
-Status.MODE_JS = "js";
-Status.MODE_HTML = "html";
-Status.MODE_TAG = "tag";
-
-
-
+Status.MODE_JS = 'js';
+Status.MODE_HTML = 'html';
+Status.MODE_TAG = 'tag';
 /**
- * Tracking the state of 
+ * Tracking the state of
  * markup while compiling.
  */
-var Markup = (function () {
-  var Markup = function Markup() {
+
+
+var Markup =
+/*#__PURE__*/
+function () {
+  function Markup() {
+    _classCallCheck(this, Markup);
+
     this.tag = null; // current tagname (if applicable)
+
     this.att = null; // current attname (not maintained!)
 
     this._is = null;
@@ -923,198 +1424,309 @@ var Markup = (function () {
     this._quotes = null;
     this._snapshots = [];
     this._index = -1;
-    this._go("txt");
-  };
 
-  Markup.prototype.next = function (c) {
-    this._index++;
-    switch (c) {
-      case "<":
-      case ">":
-        this._ontag(c);
-        break;
-      case " ":
-        this._onspace(c);
-        break;
-      case "=":
-        this._onequal(c);
-        break;
-      case "\"":
-      case "'":
-        this._onquote(c);
-        break;
-      default:
-        this._buf(c);
-        break;
+    this._go('txt');
+  }
+
+  _createClass(Markup, [{
+    key: "next",
+    value: function next(c) {
+      this._index++;
+
+      switch (c) {
+        case '<':
+        case '>':
+          this._ontag(c);
+
+          break;
+
+        case ' ':
+          this._onspace(c);
+
+          break;
+
+        case '=':
+          this._onequal(c);
+
+          break;
+
+        case '"':
+        case "'":
+          this._onquote(c);
+
+          break;
+
+        default:
+          this._buf(c);
+
+          break;
+      }
+
+      this._prevchar = c;
+      return this._is;
     }
-    this._prevchar = c;
-    return this._is;
-  };
+    /**
+     * Log snapshots to console (for debugging purpose).
+     * You can call this method over in class Runner.js
+     */
 
-  Markup.prototype.debug = function () {
-    this._debug(this._snapshots);
-  };
+  }, {
+    key: "debug",
+    value: function debug() {
+      this._debug(this._snapshots);
+    } // Private ...................................................................
 
-  Markup.prototype._ontag = function (c) {
-    if (c === "<") {
-      if (this._is === "txt") {
-        this.tag = null;
-        this._go("tag");
-      }
-    } else {
-      if (this._is === "tag") {
-        this.tag = this._buffer.trim();
-      }
-      switch (this._is) {
-        case "att":
-        case "tag":
+    /**
+     * Tag chars.
+     * @param {string} c
+     */
+
+  }, {
+    key: "_ontag",
+    value: function _ontag(c) {
+      if (c === '<') {
+        if (this._is === 'txt') {
           this.tag = null;
-          this._go("txt");
+
+          this._go('tag');
+        }
+      } else {
+        if (this._is === 'tag') {
+          this.tag = this._buffer.trim();
+        }
+
+        switch (this._is) {
+          case 'att':
+          case 'tag':
+            this.tag = null;
+
+            this._go('txt');
+
+            break;
+        }
+      }
+    }
+    /**
+     * Quote chars. We may assume the author to use double
+     * quotes, single quotes and no quotes for attributes.
+     * @param {string} c
+     */
+
+  }, {
+    key: "_onquote",
+    value: function _onquote(c) {
+      var previndex = this._index - 1;
+
+      switch (this._is) {
+        case 'val':
+          if (this._quotes) {
+            if (this._quotes === c && this._prevchar !== '\\') {
+              this._go('att');
+            }
+          } else if (this._was(previndex, 'att')) {
+            this._quotes = c;
+          }
+
+          break;
+
+        default:
+          this._buf(c);
+
           break;
       }
     }
-  };
+    /**
+     * Space chars.
+     * TODO: Important: All sorts of (multiple) whitespace characters going on!
+     * @param {string} c
+     */
 
-  Markup.prototype._onquote = function (c) {
-    var previndex = this._index - 1;
-    switch (this._is) {
-      case "val":
-        if (this._quotes) {
-          if (this._quotes === c && this._prevchar !== "\\") {
-            this._go("att");
+  }, {
+    key: "_onspace",
+    value: function _onspace(c) {
+      switch (this._is) {
+        case 'tag':
+          this.tag = this._buffer.trim();
+
+          this._go('att');
+
+          break;
+
+        case 'val':
+          if (!this._quotes) {
+            this._go('att');
           }
-        } else if (this._was(previndex, "att")) {
-          this._quotes = c;
-        }
-        break;
-      default:
+
+          break;
+
+        default:
+          this._buf(c);
+
+          break;
+      }
+    }
+    /**
+     * Equal sign.
+     * @param {string} c
+     */
+
+  }, {
+    key: "_onequal",
+    value: function _onequal(c) {
+      if (this._is === 'att') {
+        this._go('val');
+      } else {
         this._buf(c);
-        break;
-    }
-  };
-
-  Markup.prototype._onspace = function (c) {
-    switch (this._is) {
-      case "tag":
-        this.tag = this._buffer.trim();
-        this._go("att");
-        break;
-      case "val":
-        if (!this._quotes) {
-          this._go("att");
-        }
-        break;
-      default:
-        this._buf(c);
-        break;
-    }
-  };
-
-  Markup.prototype._onequal = function (c) {
-    if (this._is === "att") {
-      this._go("val");
-    } else {
-      this._buf(c);
-    }
-  };
-
-  Markup.prototype._buf = function (c) {
-    this._buffer += c;
-  };
-
-  Markup.prototype._go = function (newis) {
-    if (this._is !== null) {
-      this._snapshots.push([this._index, this._is, this._buffer]);
-    }
-    this._quotes = null;
-    this._buffer = "";
-    this._is = newis;
-  };
-
-  Markup.prototype._was = function (index, type) {
-    var ix, it, match, snap, prev, snaps = this._snapshots;
-    if (snaps.length) {
-      it = snaps.length - 1;
-      while (!match && (snap = snaps[it--])) {
-        if ((ix = snap[0]) === index) {
-          match = snap;
-        } else if (ix < index) {
-          match = prev;
-        }
-        prev = snap;
       }
-      return match && match[1] === type;
     }
-    return false;
-  };
+    /**
+     * Buffer char.
+     * @param {string} c
+     */
 
-  Markup.prototype._debug = function (snapshots) {
-    var index, is, was, buffer, yyy, next, end, tab = "\t", tabs = [];
-    console.log(snapshots.reduce(function (html, snap) {
-      index = snap[0];
-      is = snap[1];
-      buffer = snap[2];
-      switch (is) {
-        case "tag":
-          if ((end = buffer[0] === "/")) {
-            tabs.pop();
-          }
-          was = was === "txt" && yyy.trim().length ? "" : was;
-          next = (was ? "\n" + tabs.join("") : "") + "<" + buffer;
-          if (!end) {
-            tabs.push(tab);
-          }
-          break;
-        case "att":
-          next = " " + buffer.trim();
-          if (next === " ") {
-            next = "";
-          }
-          break;
-        case "val":
-          next = "=\"" + buffer + "\"";
-          break;
-        case "txt":
-          next = (was ? ">" : "") + buffer;
-          break;
+  }, {
+    key: "_buf",
+    value: function _buf(c) {
+      this._buffer += c;
+    }
+    /**
+     * Take snapshot, clear the buffer and change to new mode.
+     * @param {string} newis
+     */
+
+  }, {
+    key: "_go",
+    value: function _go(newis) {
+      if (this._is !== null) {
+        this._snapshots.push([this._index, this._is, this._buffer]);
       }
-      was = is;
-      yyy = buffer;
-      return html + next;
-    }, "") + (was === "tag" ? ">" : ""));
-  };
+
+      this._quotes = null;
+      this._buffer = '';
+      this._is = newis;
+    }
+    /**
+     * Was type at index?
+     * @param {number} index
+     * @param {string} type
+     */
+
+  }, {
+    key: "_was",
+    value: function _was(index, type) {
+      var ix,
+          it,
+          match,
+          snap,
+          prev,
+          snaps = this._snapshots;
+
+      if (snaps.length) {
+        it = snaps.length - 1;
+
+        while (!match && (snap = snaps[it--])) {
+          if ((ix = snap[0]) === index) {
+            match = snap;
+          } else if (ix < index) {
+            match = prev;
+          }
+
+          prev = snap;
+        }
+
+        return match && match[1] === type;
+      }
+
+      return false;
+    } // Deboogie ..................................................................
+
+    /**
+     * Quick and dirty debugging: The string
+     * in the console should look like HTML.
+     * @param {Array<Array<string>>} snapshots
+     */
+
+  }, {
+    key: "_debug",
+    value: function _debug(snapshots) {
+      var index,
+          is,
+          was,
+          buffer,
+          yyy,
+          next,
+          end,
+          tab = '\t',
+          tabs = [];
+      console.log(snapshots.reduce(function (html, snap) {
+        index = snap[0];
+        is = snap[1];
+        buffer = snap[2];
+
+        switch (is) {
+          case 'tag':
+            if (end = buffer[0] === '/') {
+              tabs.pop();
+            }
+
+            was = was === 'txt' && yyy.trim().length ? '' : was;
+            next = (was ? '\n' + tabs.join('') : '') + '<' + buffer;
+
+            if (!end) {
+              tabs.push(tab);
+            }
+
+            break;
+
+          case 'att':
+            next = ' ' + buffer.trim();
+
+            if (next === ' ') {
+              next = '';
+            }
+
+            break;
+
+          case 'val':
+            next = '="' + buffer + '"';
+            break;
+
+          case 'txt':
+            next = (was ? '>' : '') + buffer;
+            break;
+        }
+
+        was = is;
+        yyy = buffer;
+        return html + next;
+      }, '') + (was === 'tag' ? '>' : ''));
+    }
+  }]);
 
   return Markup;
-})();
+}(); // Static ......................................................................
 
 
-
-
-// Static ......................................................................
-
-Markup.CONTEXT_TXT = "txt";
-Markup.CONTEXT_ATT = "att";
-Markup.CONTEXT_VAL = "val";
-
-
-
+Markup.CONTEXT_TXT = 'txt';
+Markup.CONTEXT_ATT = 'att';
+Markup.CONTEXT_VAL = 'val';
 /**
  * Collecting JS code.
  */
-var Output =
 
+
+var Output =
 /**
  * @param @optional {string} body
  */
-function Output(body) {
-  if (body === undefined) body = "";
+function Output() {
+  var body = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
+
+  _classCallCheck(this, Output);
+
   this.body = body;
   this.temp = null;
 };
-
-
-
-
 
 /**
  * @param {string} source
@@ -1123,8 +1735,10 @@ function Output(body) {
  * @param {Map<String,object>} directives
  * @returns {string}
  */
+
+
 exports.compile = function (edbml, options, macros, directives) {
-  if (edbml.contains("<?input")) {
+  if (edbml.contains('<?input')) {
     return new ScriptCompiler().compile(edbml, options, macros, directives);
   } else {
     return new FunctionCompiler().compile(edbml, options, macros, directives);

--- a/tasks/things/formatter.js
+++ b/tasks/things/formatter.js
@@ -1,7 +1,7 @@
-"use strict";
+'use strict';
 
-var beautyfier = require("esformatter");
-var uglifier = require("uglify-js");
+var beautyfier = require('prettier');
+var uglifier = require('uglify-js');
 
 /**
  * Format JS for readability.
@@ -13,11 +13,15 @@ var uglifier = require("uglify-js");
 exports.beautify = function(js, tab, buffer) {
 	tab = tab || '';
 	js = beautyfier.format(js, beautyoptions());
-	js = js.split('\n').filter(function(line, i) {
-		return line.trim().length;
-	}).map(function(line) {
-		return tab + line;
-	}).join('\n');
+	js = js
+		.split('\n')
+		.filter(function(line, i) {
+			return line.trim().length;
+		})
+		.map(function(line) {
+			return tab + line;
+		})
+		.join('\n');
 	js = buffer ? '\n' + js + '\n' + tab : js;
 	return simplified(js);
 };
@@ -36,7 +40,6 @@ exports.uglify = function(js) {
 	}).code;
 };
 
-
 // Private ...............................
 
 /**
@@ -45,18 +48,27 @@ exports.uglify = function(js) {
  */
 function beautyoptions() {
 	return {
-		preset: "default",
-		indent: {
-			value: "  "
-		},
-		lineBreak: {
-			keepEmptyLines: 0
-		}
+		parser: 'babylon',
+		printWidth: 80,
+		tabWidth: 2,
+		useTabs: true,
+		semi: true,
+		singleQuote: true,
+		jsxSingleQuote: false,
+		trailingComma: 'none',
+		bracketSpacing: true,
+		jsxBracketSameLine: false,
+		arrowParens: 'avoid',
+		requirePragma: false,
+		insertPragma: false,
+		proseWrap: 'never',
+		htmlWhitespaceSensitivity: 'css',
+		endOfLine: 'auto'
 	};
 }
 
 /**
- * Substiture repeated lines of `out.html +=` with simple 
+ * Substiture repeated lines of `out.html +=` with simple
  * `+` concatenation. Watch out for hardcoded strings here.
  * @param {string} js
  * @returns {string}
@@ -69,7 +81,7 @@ function simplified(js) {
 	var fixes = [];
 	var lines = js.split('\n').map(function(line, index) {
 		go = line.trim().startsWith(here);
-		if(is && go) {
+		if (is && go) {
 			line = line.replace(here, gone);
 			fixes.push(index - 1);
 		}
@@ -77,7 +89,7 @@ function simplified(js) {
 		return line;
 	});
 	fixes.forEach(function(index) {
-		if(index > -1) {
+		if (index > -1) {
 			var line = lines[index];
 			lines[index] = line.replace(/;$/, ' +');
 		}

--- a/tasks/things/inliner.js
+++ b/tasks/things/inliner.js
@@ -19,7 +19,9 @@ exports.process = function(grunt, files, options, macros, done) {
 		isExpandedPair = filePair.orig.expand || false;
 		filePair.src.forEach(function(src) {
 			if (detectDestType(grunt, filePair.dest) === 'directory') {
-				dest = (isExpandedPair) ? filePair.dest : unixifyPath(path.join(filePair.dest, src));
+				dest = isExpandedPair
+					? filePair.dest
+					: unixifyPath(path.join(filePair.dest, src));
 			} else {
 				dest = filePair.dest;
 			}
@@ -34,7 +36,6 @@ exports.process = function(grunt, files, options, macros, done) {
 	done();
 };
 
-
 // Private .....................................................................
 
 function detectDestType(grunt, dest) {
@@ -45,9 +46,9 @@ function detectDestType(grunt, dest) {
 	}
 }
 
-
 function unixifyPath(filepath) {
-	if (false) { //process.platform === 'win32'
+	if (false) {
+		//process.platform === 'win32'
 		return filepath.replace(/\\/g, '/');
 	} else {
 		return filepath;
@@ -83,9 +84,7 @@ function resolvescripts(grunt, src, options, macros) {
 			var id = script.attr('id');
 			var key = id || assistant.unique(src, i);
 			var tab = tabbing(script);
-			holders[key] = convertinline(
-				script, options, macros, key, tab, id
-			);
+			holders[key] = convertinline(script, options, macros, key, tab, id);
 		}
 	});
 	if (Object.keys(holders).length) {
@@ -113,16 +112,20 @@ function resolvehtml(html, holders) {
  * @param {Map} options
  */
 function convertinline(script, options, macros, key, tab, id) {
-	var js, directives = assistant.directives(script);
-	var scriptid = id || ('edbml.' + key); // TODO: is this right (with the id)?
+	var js,
+		directives = assistant.directives(script);
+	var scriptid = id || 'edbml.' + key; // TODO: is this right (with the id)?
 	var result = compiler.compile(script.html(), options, macros, directives); // 'edb' + key
 	js = assistant.declare(scriptid, result);
-	js = options.beautify ? formatter.beautify(js, tab, true) : formatter.uglify(js);
+	js = options.beautify
+		? formatter.beautify(js, tab, true)
+		: formatter.uglify(js);
 	script.html(placeholder(key)).removeAttr('type');
-	if (!id) { // TODO: should gui.scriptid always be present? Think about this!
-		script.addClass("gui-script");
+	if (!id) {
+		// TODO: should gui.scriptid always be present? Think about this!
+		script.addClass('gui-script');
 		var att = options.attribute || 'gui';
-		script.attr(att + ".scriptid", scriptid);
+		script.attr(att + '.scriptid', scriptid);
 	}
 	return js;
 }

--- a/tasks/things/macrunner.js
+++ b/tasks/things/macrunner.js
@@ -8,12 +8,10 @@ var sweet = require('sweet.js');
  * @param {Map<string,string>} options
  */
 exports.init = function(grunt, options) {
-
 	// TODO: load from options
 	sweet.loadMacro(__dirname + '/macros/@.sjs');
 
 	return {
-
 		/*
 		 * Release the macros.
 		 * @param {string} string

--- a/tasks/things/outliner.js
+++ b/tasks/things/outliner.js
@@ -1,11 +1,11 @@
-"use strict";
+'use strict';
 
-var cheerio = require("cheerio");
+var cheerio = require('cheerio');
 var chalk = require('chalk');
-var compiler = require("./compiler");
-var formatter = require("./formatter");
-var assistant = require("./assistant");
-var path = require("path");
+var compiler = require('./compiler');
+var formatter = require('./formatter');
+var assistant = require('./assistant');
+var path = require('path');
 
 /**
  * Concat and minify files.
@@ -23,15 +23,14 @@ exports.process = function(grunt, files, options, macros, done) {
 			if (results.length && !errors) {
 				target = grunt.template.process(target);
 				grunt.file.write(target, results);
-				grunt.log.writeln("File " + chalk.cyan(target) + ' created.');
+				grunt.log.writeln('File ' + chalk.cyan(target) + ' created.');
 			}
 		});
 		done();
 	} else {
-		grunt.log.error("Object expected");
+		grunt.log.error('Object expected');
 	}
 };
-
 
 // Private ...............................................................................
 
@@ -62,7 +61,9 @@ function error(message) {
  * @returns {string}
  */
 function trawloutline(grunt, sources, options, macros) {
-	var js, $, results = [];
+	var js,
+		$,
+		results = [];
 	sources.forEach(function(src) {
 		$ = cheerio.load(grunt.file.read(src));
 		getscripts($, src, options).each(function(i, script) {
@@ -70,29 +71,32 @@ function trawloutline(grunt, sources, options, macros) {
 			results.push(comment(src) + formatter.beautify(js));
 		});
 	});
-	return results.join("\n\n");
+	return results.join('\n\n');
 }
 
 /**
  * @returns {$}
  */
 function getscripts($, src) {
-	var scripts = $("script");
+	var scripts = $('script');
 	if (scripts.length === 1) {
-		var name, script = $(scripts[0]);
-		if (!script.attr("id")) {
+		var name,
+			script = $(scripts[0]);
+		if (!script.attr('id')) {
 			name = path.basename(src);
 			if (validname(name)) {
-				script.attr("id", name);
+				script.attr('id', name);
 			} else {
-				error("File name unfit for declaration as a JS object: " + name);
+				error('File name unfit for declaration as a JS object: ' + name);
 			}
 		}
 	} else {
-		if (!Array.prototype.every.call(scripts, function(script) {
-			return $(script).attr("id");
-		})) {
-			error("ID required when multiples script in file: " + src);
+		if (
+			!Array.prototype.every.call(scripts, function(script) {
+				return $(script).attr('id');
+			})
+		) {
+			error('ID required when multiples script in file: ' + src);
 		}
 	}
 	return scripts;
@@ -103,7 +107,7 @@ function getscripts($, src) {
  * @returns {boolean}
  */
 function validname(name) {
-	name = name.replace(/\./g, "");
+	name = name.replace(/\./g, '');
 	return name.match(IDENTIFIER) ? true : false;
 }
 
@@ -114,7 +118,7 @@ function validname(name) {
  * @returns {string}
  */
 function parse(script, options, macros) {
-	var name = script.attr("id");
+	var name = script.attr('id');
 	var text = script.text();
 	var atts = assistant.directives(script);
 	return compile(name, text, options, macros, atts);

--- a/tasks/things/shorthash.js
+++ b/tasks/things/shorthash.js
@@ -10,14 +10,13 @@ exports.bitwise = bitwise;
 exports.binaryTransfer = binaryTransfer;
 exports.unique = unique;
 
-
 // refer to: http://werxltd.com/wp/2010/05/13/javascript-implementation-of-javas-string-hashcode-method/
 function bitwise(str) {
 	var hash = 0;
 	if (str.length == 0) return hash;
 	for (var i = 0; i < str.length; i++) {
 		var ch = str.charCodeAt(i);
-		hash = ((hash << 5) - hash) + ch;
+		hash = (hash << 5) - hash + ch;
 		hash = hash & hash; // Convert to 32bit integer
 	}
 	return hash;
@@ -55,7 +54,6 @@ function binaryTransfer(integer, binary) {
 
 	return sign + result;
 }
-
 
 /**
  * why choose 61 binary, because we need the last element char to replace the minus sign

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,5 +1,5 @@
 /*global module*/
-module.exports = function (config) {
+module.exports = function(config) {
 	'use strict';
 	var pack = require('../package.json');
 	console.log('../dist/spiritual-gui-' + pack.version + '.js');
@@ -7,7 +7,7 @@ module.exports = function (config) {
 		frameworks: ['jasmine'],
 		files: [
 			'karma.setup.js',
-			'build/**/*.js',
+			'build/**/*.js'
 			//{pattern: 'xxx', included: false}
 		],
 		browsers: ['Chrome'],

--- a/test/karma.setup.js
+++ b/test/karma.setup.js
@@ -4,8 +4,8 @@
  */
 (function setup(oldstart) {
 	window.__karma__.start = function delay() {
-		document.addEventListener("DOMContentLoaded", function () {
+		document.addEventListener('DOMContentLoaded', function() {
 			setTimeout(oldstart);
 		});
 	};
-}(window.__karma__.start));
+})(window.__karma__.start);


### PR DESCRIPTION
@wiredearp 

Another one for capitalism!

* `esformatter` => `prettier`
* `6to5@^1.13.2` => `@babel/core@^7.1.6` + `@babel/preset-env@^7.1.6`

Updated everything else, until `npm audit` said the coast was clear.


### Before
```
> npm audit

found 26 vulnerabilities (14 low, 12 high) in 275 scanned packages
  run `npm audit fix` to fix 2 of them.
  22 vulnerabilities require semver-major dependency updates.
  2 vulnerabilities require manual review.
```

### After
```
> npm audit

found 0 vulnerabilities
 in 4267 scanned packages
```


Related to https://github.com/wunderbyte/grunt-spiritual-build/pull/15